### PR TITLE
docker-compose.regtest.yml fixes

### DIFF
--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -11,12 +11,12 @@ services:
       dockerfile: DockerFile
     environment:
       NBXPLORER_NETWORK: regtest
-      NBXPLORER_RPCURL: http://bitcoind:49372/
-      NBXPLORER_RPCUSER: ceiwHEbqWI83
-      NBXPLORER_RPCPASSWORD: DwubwWsoo3
-      NBXPLORER_NODEENDPOINT: bitcoind:8332
       NBXPLORER_BIND: 0.0.0.0:32838
       NBXPLORER_NOAUTH: 1
+      NBXPLORER_BTCRPCURL: http://bitcoind:49372/
+      NBXPLORER_BTCRPCUSER: ceiwHEbqWI83
+      NBXPLORER_BTCRPCPASSWORD: DwubwWsoo3
+      NBXPLORER_BTCNODEENDPOINT: bitcoind:8332
     links:
       - bitcoind
 

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -8,7 +8,6 @@ services:
       - 32838
     build:
       context: .
-      dockerfile: Dockerfile
     environment:
       NBXPLORER_NETWORK: regtest
       NBXPLORER_BIND: 0.0.0.0:32838

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -8,7 +8,7 @@ services:
       - 32838
     build:
       context: .
-      dockerfile: DockerFile
+      dockerfile: Dockerfile
     environment:
       NBXPLORER_NETWORK: regtest
       NBXPLORER_BIND: 0.0.0.0:32838


### PR DESCRIPTION
I couldn't use environment variables passed from docker-compose because vars didn't include BTC prefixes. Now I can use them with containers. I thought there was a usage change to support multiple coins, but docker-compose file became out-of-date.