### PR TITLE
Fixed bug in Dogecoin initalization

### DIFF
--- a/NBXplorer.Client/NBXplorerNetworkProvider.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.cs
@@ -10,7 +10,7 @@ namespace NBXplorer
 		{
 			InitBitcoin(chainType);
 			InitLitecoin(chainType);
-			InitDogecoin(ChainType);
+			InitDogecoin(chainType);
 			InitBCash(chainType);
 			ChainType = chainType;
 			foreach(var chain in _Networks.Values)


### PR DESCRIPTION
Fixed misspelling which lead always initializing Regnet for Dogecoin

I still think doge synchronization not working on mainnet, as header format was changed after 371,337 block.

https://github.com/dogecoin/dogecoin/blob/master/doc/release-notes/RELEASE_NOTES_1_8.1.md