### PR TITLE
Dash min rpc version and ChainLoadingTimeout

### DIFF
--- a/NBXplorer.Client/NBXplorerNetwork.cs
+++ b/NBXplorer.Client/NBXplorerNetwork.cs
@@ -42,6 +42,12 @@ namespace NBXplorer
 			internal set;
 		} = true;
 
+		public TimeSpan ChainLoadingTimeout
+		{
+			get;
+			set;
+		} = TimeSpan.FromMinutes(15);
+
 		public override string ToString()
 		{
 			return CryptoCode.ToString();

--- a/NBXplorer.Client/NBXplorerNetworkProvider.Dash.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Dash.cs
@@ -12,7 +12,7 @@ namespace NBXplorer
 			Add(new NBXplorerNetwork()
 			{
 				CryptoCode = "DASH",
-				MinRPCVersion = 120203,
+				MinRPCVersion = 120000,
 				NBitcoinNetwork = chainType == ChainType.Main ? NBitcoin.Altcoins.Dash.Mainnet :
 								  chainType == ChainType.Test ? NBitcoin.Altcoins.Dash.Testnet :
 								  chainType == ChainType.Regtest ? NBitcoin.Altcoins.Dash.Regtest : throw new NotSupportedException(chainType.ToString()),

--- a/NBXplorer.Client/NBXplorerNetworkProvider.Dogecoin.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Dogecoin.cs
@@ -17,6 +17,7 @@ namespace NBXplorer
 								  chainType == ChainType.Test ? NBitcoin.Altcoins.Dogecoin.Testnet :
 								  chainType == ChainType.Regtest ? NBitcoin.Altcoins.Dogecoin.Regtest : throw new NotSupportedException(chainType.ToString()),
 				DefaultSettings = NBXplorerDefaultSettings.GetDefaultSettings(chainType),
+				ChainLoadingTimeout = TimeSpan.FromHours(1),
 				SupportCookieAuthentication = false
 			});
 		}

--- a/NBXplorer/BitcoinDWaiter.cs
+++ b/NBXplorer/BitcoinDWaiter.cs
@@ -339,7 +339,7 @@ namespace NBXplorer
 			var heightBefore = _Chain.Height;
 			using(var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellation))
 			{
-				timeout.CancelAfter(TimeSpan.FromMinutes(15));
+				timeout.CancelAfter(_Network.ChainLoadingTimeout);
 				try
 				{
 					await LoadChainFromNode(timeout.Token);


### PR DESCRIPTION
Doge chain takes very long to sync because of 2.1M+ blocks, new settings allow specify timeout for each coin.