### PR TITLE
Adds BlockId to the Transaction result output

### DIFF
--- a/NBXplorer.Client/Models/TransactionResult.cs
+++ b/NBXplorer.Client/Models/TransactionResult.cs
@@ -20,6 +20,18 @@ namespace NBXplorer.Models
 			}
 		}
 
+		uint256 _BlockId;
+		public uint256 BlockId
+		{
+			get
+			{
+				return _BlockId;
+			}
+			set
+			{
+				_BlockId = value;
+			}
+		}
 
 		Transaction _Transaction;
 		public Transaction Transaction

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -812,6 +812,7 @@ namespace NBXplorer.Tests
 				var tx = tester.Client.GetTransaction(utxo.Unconfirmed.UTXOs[0].Outpoint.Hash);
 				Assert.NotNull(tx);
 				Assert.Equal(0, tx.Confirmations);
+				Assert.Null(tx.BlockId);
 				Assert.Equal(utxo.Unconfirmed.UTXOs[0].Outpoint.Hash, tx.Transaction.GetHash());
 				Assert.Equal(unconfTimestamp, tx.Timestamp);
 
@@ -862,6 +863,7 @@ namespace NBXplorer.Tests
 				Assert.NotNull(tx);
 				Assert.Equal(unconfTimestamp, tx.Timestamp);
 				Assert.Equal(1, tx.Confirmations);
+				Assert.NotNull(tx.BlockId);
 				Assert.Equal(utxo.Confirmed.UTXOs[0].Outpoint.Hash, tx.Transaction.GetHash());
 				tester.RPC.Generate(1);
 
@@ -871,6 +873,7 @@ namespace NBXplorer.Tests
 
 				tx = tester.Client.GetTransaction(tx.Transaction.GetHash());
 				Assert.Equal(2, tx.Confirmations);
+				Assert.NotNull(tx.BlockId);
 
 				var outpoint01 = utxo.Confirmed.UTXOs[0].Outpoint;
 
@@ -887,6 +890,7 @@ namespace NBXplorer.Tests
 
 				tx = tester.Client.GetTransaction(tx.Transaction.GetHash());
 				Assert.Equal(3, tx.Confirmations);
+				Assert.NotNull(tx.BlockId);
 
 				utxo = tester.Client.GetUTXOs(pubkey, utxo, false);
 				Assert.True(!utxo.HasChanges);

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -345,7 +345,7 @@ namespace NBXplorer.Controllers
 
 			var conf = confBlock == null ? 0 : chain.Tip.Height - confBlock.Height + 1;
 
-			return new TransactionResult() { Confirmations = conf, Transaction = includeTransaction ? oldest.Transaction : null, Height = confBlock?.Height, Timestamp = oldest.Timestamp };
+			return new TransactionResult() { Confirmations = conf, BlockId = confBlock?.HashBlock, Transaction = includeTransaction ? oldest.Transaction : null, Height = confBlock?.Height, Timestamp = oldest.Timestamp };
 		}
 
 		[HttpPost]


### PR DESCRIPTION
 It's provided in a NewTransactionEvent but was missing here. Shouldn't be any reason to exclude it that I could see, and it's needed when querying Transactions for confirmations where no event was received.