### PR TITLE
Added Azure Service Bus support

### DIFF
--- a/NBXplorer.Client/Models/NewBlockEvent.cs
+++ b/NBXplorer.Client/Models/NewBlockEvent.cs
@@ -1,12 +1,9 @@
 ﻿using NBitcoin;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace NBXplorer.Models
 {
-    public class NewBlockEvent
-    {
+	public class NewBlockEvent : NewEventBase
+	{
 		public int Height
 		{
 			get; set;
@@ -19,11 +16,6 @@ namespace NBXplorer.Models
 		public uint256 PreviousBlockHash
 		{
 			get; set;
-		}
-		public string CryptoCode
-		{
-			get;
-			set;
 		}
 	}
 }

--- a/NBXplorer.Client/Models/NewBlockEventRequest.cs
+++ b/NBXplorer.Client/Models/NewBlockEventRequest.cs
@@ -1,20 +1,7 @@
-﻿using NBitcoin;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NBXplorer.Models
+﻿namespace NBXplorer.Models
 {
-    public class NewBlockEventRequest
-    {
-		public NewBlockEventRequest()
-		{
+	public class NewBlockEventRequest : NewEventBase
+	{
 
-		}
-
-		public String CryptoCode
-		{
-			get; set;
-		}
 	}
 }

--- a/NBXplorer.Client/Models/NewEventBase.cs
+++ b/NBXplorer.Client/Models/NewEventBase.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace NBXplorer.Models
+{
+	public abstract class NewEventBase
+	{
+		public string CryptoCode
+		{
+			get;
+			set;
+		}
+
+		public JObject ToJObject(JsonSerializerSettings settings)
+		{
+			var typeName = ExtensionsClient.GetNotificationMessageTypeName(this.GetType());
+			if (typeName == null)
+				throw new InvalidOperationException($"{this.GetType().Name} does not have an associated typeName");
+			JObject jobj = new JObject();
+			var serialized = JsonConvert.SerializeObject(this, settings);
+			var data = JObject.Parse(serialized);
+			jobj.Add(new JProperty("type", new JValue(typeName)));
+			jobj.Add(new JProperty("data", data));
+
+			return jobj;
+		}
+
+		public string ToJson(JsonSerializerSettings settings)
+		{
+			return JsonConvert.SerializeObject(this, settings);
+		}
+	}
+}

--- a/NBXplorer.Client/Models/NewTransactionEvent.cs
+++ b/NBXplorer.Client/Models/NewTransactionEvent.cs
@@ -6,7 +6,7 @@ using NBXplorer.DerivationStrategy;
 
 namespace NBXplorer.Models
 {
-	public class NewTransactionEvent
+	public class NewTransactionEvent : NewEventBase
 	{
 		public uint256 BlockId
 		{
@@ -32,11 +32,7 @@ namespace NBXplorer.Models
 		{
 			get; set;
 		} = new List<KeyPathInformation>();
-		public string CryptoCode
-		{
-			get;
-			set;
-		}
+
 
 		public TransactionMatch AsMatch()
 		{

--- a/NBXplorer.Client/Models/NewTransactionEventRequest.cs
+++ b/NBXplorer.Client/Models/NewTransactionEventRequest.cs
@@ -1,23 +1,7 @@
-﻿using NBXplorer.DerivationStrategy;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NBXplorer.Models
+﻿namespace NBXplorer.Models
 {
-    public class NewTransactionEventRequest
-    {
-		public NewTransactionEventRequest()
-		{
-
-		}
-		public string CryptoCode
-		{
-			get; set;
-		}
-		public string[] DerivationSchemes
-		{
-			get; set;
-		}
+	public class NewTransactionEventRequest : NewEventBase
+	{
+		public string[] DerivationSchemes { get; set; }
 	}
 }

--- a/NBXplorer.Tests/NBXplorer.Tests.csproj
+++ b/NBXplorer.Tests/NBXplorer.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+      <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
       <PackageReference Include="NBitcoin.TestFramework" Version="1.6.7" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
 	  <PackageReference Include="xunit" Version="2.3.1" />

--- a/NBXplorer.Tests/ServerTester.cs
+++ b/NBXplorer.Tests/ServerTester.cs
@@ -103,6 +103,11 @@ namespace NBXplorer.Tests
 				keyValues.Add(("maxgapsize", "4"));
 				keyValues.Add(($"{CryptoCode.ToLowerInvariant()}startheight", Explorer.CreateRPCClient().GetBlockCount().ToString()));
 				keyValues.Add(($"{CryptoCode.ToLowerInvariant()}nodeendpoint", $"{Explorer.Endpoint.Address}:{Explorer.Endpoint.Port}"));
+				keyValues.Add(("asbcnstr", AzureServiceBusTestConfig.ConnectionString));
+				keyValues.Add(("asbblockq", AzureServiceBusTestConfig.NewBlockQueue));
+				keyValues.Add(("asbtranq", AzureServiceBusTestConfig.NewTransactionQueue));
+				keyValues.Add(("asbblockt", AzureServiceBusTestConfig.NewBlockTopic));
+				keyValues.Add(("asbtrant", AzureServiceBusTestConfig.NewTransactionTopic));
 
 				var args = keyValues.SelectMany(kv => new[] { $"--{kv.key}", kv.value }).ToArray();
 				Host = new WebHostBuilder()

--- a/NBXplorer.Tests/TestConfig.cs
+++ b/NBXplorer.Tests/TestConfig.cs
@@ -1,0 +1,62 @@
+﻿namespace NBXplorer.Tests
+{
+	public static class AzureServiceBusTestConfig
+	{
+		public static string ConnectionString
+		{
+			get
+			{
+				//Put your service bus connection string here - requires READ / WRITE permissions
+				return "";
+			}
+		}
+
+		public static string NewBlockQueue
+		{
+			get
+			{
+				return "newblock";
+			}
+		}
+		public static string NewBlockTopic
+		{
+			get
+			{
+				return "newbitcoinblock";
+			}
+		}
+
+		public static string NewBlockSubscription
+		{
+			get
+			{
+				return "NewBlock";
+			}
+		}
+
+		public static string NewTransactionQueue
+		{
+			get
+			{
+				return "newtransaction";
+			}
+		}
+
+		public static string NewTransactionTopic
+		{
+			get
+			{
+				return "newbitcointransaction";
+			}
+		}
+
+		public static string NewTransactionSubscription
+		{
+			get
+			{
+				return "NewTransaction";
+			}
+		}
+
+	}
+}

--- a/NBXplorer/Configuration/DefaultConfiguration.cs
+++ b/NBXplorer/Configuration/DefaultConfiguration.cs
@@ -44,6 +44,11 @@ namespace NBXplorer.Configuration
 				app.Option($"--{crypto}nodeendpoint", $"The p2p connection to a Bitcoin node, make sure you are whitelisted (default: default p2p node on localhost, depends on network)", CommandOptionType.SingleValue);
 			}
 
+			app.Option("--asbcnstr", "[For Azure Service Bus] Azure Service Bus Connection string. New Block and New Transaction messages will be pushed to queues when this values is set", CommandOptionType.SingleValue);
+			app.Option("--asbblockq", "[For Azure Service Bus] Name of Queue to push new block message to. Leave blank to turn off", CommandOptionType.SingleValue);
+			app.Option("--asbtranq", "[For Azure Service Bus] Name of Queue to push new transaction message to. Leave blank to turn off", CommandOptionType.SingleValue);
+			app.Option("--asbblockt", "[For Azure Service Bus] Name of Topic to push new block message to. Leave blank to turn off", CommandOptionType.SingleValue);
+			app.Option("--asbtrant", "[For Azure Service Bus] Name of Topic to push new transaction message to. Leave blank to turn off", CommandOptionType.SingleValue);
 			app.Option("--maxgapsize", $"The maximum gap address count on which the explorer will track derivation schemes (default: 30)", CommandOptionType.SingleValue);
 			app.Option("--mingapsize", $"The minimum gap address count on which the explorer will track derivation schemes (default: 20)", CommandOptionType.SingleValue);
 			app.Option("--noauth", $"Disable cookie authentication", CommandOptionType.BoolValue);
@@ -145,6 +150,16 @@ namespace NBXplorer.Configuration
 			builder.AppendLine("#port=" + settings.DefaultPort);
 			builder.AppendLine("#bind=127.0.0.1");
 			builder.AppendLine($"#{networkType.ToString().ToLowerInvariant()}=1");
+			builder.AppendLine();
+			builder.AppendLine();
+			builder.AppendLine("####Azure Service Bus####");
+			builder.AppendLine("## Azure Service Bus configuration - set connection string to use Service Bus. Set Queue and / or Topic names to publish message to queues / topics");
+			builder.AppendLine("#asbcnstr=Endpoint=sb://<yourdomain>.servicebus.windows.net/;SharedAccessKeyName=<your key name here>;SharedAccessKey=<your key here>");
+			builder.AppendLine("#asbblockq=<new block queue name>");
+			builder.AppendLine("#asbtranq=<new transaction queue name>");
+			builder.AppendLine("#asbblockt=<new block topic name>");
+			builder.AppendLine("#asbtrant=<new transaction topic name>");
+
 			return builder.ToString();
 		}
 

--- a/NBXplorer/Configuration/ExplorerConfiguration.cs
+++ b/NBXplorer/Configuration/ExplorerConfiguration.cs
@@ -144,6 +144,13 @@ namespace NBXplorer.Configuration
 				Directory.CreateDirectory(DataDir);
 			CacheChain = config.GetOrDefault<bool>("cachechain", true);
 			NoAuthentication = config.GetOrDefault<bool>("noauth", false);
+
+			AzureServiceBusConnectionString = config.GetOrDefault<string>("asbcnstr", "");
+			AzureServiceBusBlockQueue = config.GetOrDefault<string>("asbblockq", "");
+			AzureServiceBusTransactionQueue = config.GetOrDefault<string>("asbtranq", "");
+			AzureServiceBusBlockTopic = config.GetOrDefault<string>("asbblockt", "");
+			AzureServiceBusTransactionTopic = config.GetOrDefault<string>("asbtrant", "");
+
 			return this;
 		}
 
@@ -158,6 +165,34 @@ namespace NBXplorer.Configuration
 			set;
 		}
 		public bool NoAuthentication
+		{
+			get;
+			set;
+		}
+		public string AzureServiceBusConnectionString
+		{
+			get;
+			set;
+		}
+
+		public string AzureServiceBusBlockQueue
+		{
+			get;
+			set;
+		}
+
+		public string AzureServiceBusBlockTopic
+		{
+			get;
+			set;
+		}
+
+		public string AzureServiceBusTransactionQueue
+		{
+			get;
+			set;
+		}
+		public string AzureServiceBusTransactionTopic
 		{
 			get;
 			set;

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -280,7 +280,7 @@ namespace NBXplorer.Controllers
 						CryptoCode = o.CryptoCode,
 						DerivationStrategy = o.Match.DerivationStrategy,
 						BlockId = blockHeader?.Hash,
-						TransactionData = ToTransactionResult(includeTransaction, chain, new[] { o.SavedTransaction }),
+						TransactionData = Utils.ToTransactionResult(includeTransaction, chain, new[] { o.SavedTransaction }),
 						Inputs = o.Match.Inputs,
 						Outputs = o.Match.Outputs
 					});
@@ -340,25 +340,7 @@ namespace NBXplorer.Controllers
 			var result = RepositoryProvider.GetRepository(network).GetSavedTransactions(txId);
 			if(result.Length == 0)
 				return NotFound();
-			return Json(ToTransactionResult(includeTransaction, chain, result));
-		}
-
-		private TransactionResult ToTransactionResult(bool includeTransaction, SlimChain chain, Repository.SavedTransaction[] result)
-		{
-			var noDate = NBitcoin.Utils.UnixTimeToDateTime(0);
-			var oldest = result
-							.Where(o => o.Timestamp != noDate)
-							.OrderBy(o => o.Timestamp).FirstOrDefault() ?? result.First();
-
-			var confBlock = result
-						.Where(r => r.BlockHash != null)
-						.Select(r => chain.GetBlock(r.BlockHash))
-						.Where(r => r != null)
-						.FirstOrDefault();
-
-			var conf = confBlock == null ? 0 : chain.Height - confBlock.Height + 1;
-
-			return new TransactionResult() { Confirmations = conf, BlockId = confBlock?.Hash, Transaction = includeTransaction ? oldest.Transaction : null, Height = confBlock?.Height, Timestamp = oldest.Timestamp };
+			return Json(Utils.ToTransactionResult(includeTransaction, chain, result));
 		}
 
 		[HttpPost]

--- a/NBXplorer/Extensions.cs
+++ b/NBXplorer/Extensions.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Authentication;
 using NBXplorer.Authentication;
 using NBitcoin.DataEncoders;
 using System.Text.RegularExpressions;
+using NBXplorer.MessageBrokers;
 
 namespace NBXplorer
 {
@@ -175,6 +176,7 @@ namespace NBXplorer
 			services.AddSingleton<IHostedService, AddressPoolService>();
 			services.TryAddSingleton<BitcoinDWaitersAccessor>();
 			services.AddSingleton<IHostedService, BitcoinDWaiters>();
+			services.AddSingleton<IHostedService, AzureServiceBus>();
 
 			services.AddSingleton<ExplorerConfiguration>(o => o.GetRequiredService<IOptions<ExplorerConfiguration>>().Value);
 

--- a/NBXplorer/MessageBrokers/AzureServiceBus.cs
+++ b/NBXplorer/MessageBrokers/AzureServiceBus.cs
@@ -1,0 +1,163 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NBXplorer.Configuration;
+using NBXplorer.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NBXplorer.MessageBrokers
+{
+	public class AzureServiceBus : IHostedService
+	{
+		EventAggregator _EventAggregator;
+		bool _Disposed = false;
+		CompositeDisposable _subscriptions = new CompositeDisposable();
+		IQueueClient _queueBlk = null;
+		IQueueClient _queueTran = null;
+		ITopicClient _topicBlk = null;
+		ITopicClient _topicTran = null;
+		ExplorerConfiguration _config;
+		JsonSerializerSettings _serializerSettings;
+
+		public AzureServiceBus(BitcoinDWaitersAccessor waiters, ChainProvider chainProvider, EventAggregator eventAggregator, IOptions<ExplorerConfiguration> config, IOptions<MvcJsonOptions> jsonOptions)
+		{
+			_EventAggregator = eventAggregator;
+			ChainProvider = chainProvider;
+			Waiters = waiters.Instance;
+			_config = config.Value;
+
+			_serializerSettings = jsonOptions.Value.SerializerSettings;
+		}
+
+		public Task StartAsync(CancellationToken cancellationToken)
+		{
+			if (_Disposed)
+				throw new ObjectDisposedException(nameof(AzureServiceBus));
+
+			if (string.IsNullOrWhiteSpace(_config.AzureServiceBusConnectionString))
+			{
+				Logs.Explorer.LogInformation("[Azure Service Bus] No connection string configured - Azure service bus will not be used");
+				return Task.CompletedTask;
+			}
+
+			if (!string.IsNullOrWhiteSpace(_config.AzureServiceBusBlockQueue))
+				_queueBlk = new QueueClient(_config.AzureServiceBusConnectionString, _config.AzureServiceBusBlockQueue);
+
+			if (!string.IsNullOrWhiteSpace(_config.AzureServiceBusTransactionQueue))
+				_queueTran = new QueueClient(_config.AzureServiceBusConnectionString, _config.AzureServiceBusTransactionQueue);
+
+			if (!string.IsNullOrWhiteSpace(_config.AzureServiceBusBlockTopic))
+				_topicBlk = new TopicClient(_config.AzureServiceBusConnectionString, _config.AzureServiceBusBlockTopic);
+
+			if (!string.IsNullOrWhiteSpace(_config.AzureServiceBusTransactionTopic))
+				_topicTran = new TopicClient(_config.AzureServiceBusConnectionString, _config.AzureServiceBusTransactionTopic);
+
+
+			_subscriptions.Add(_EventAggregator.Subscribe<Events.NewBlockEvent>(async o =>
+			{
+				var chain = ChainProvider.GetChain(o.CryptoCode);
+				if (chain == null)
+					return;
+				var block = chain.GetBlock(o.BlockId);
+				if (block != null)
+				{
+					var nbe = new Models.NewBlockEvent()
+					{
+						CryptoCode = o.CryptoCode,
+						Hash = block.Hash,
+						Height = block.Height,
+						PreviousBlockHash = block?.Previous
+					};
+
+					string jsonMsg = nbe.ToJson(_serializerSettings);
+					var bytes = Encoding.UTF8.GetBytes(jsonMsg);
+					var message = new Message(bytes);
+					message.ContentType = nbe.GetType().ToString();
+					message.MessageId = block.Hash.ToString();          //Used for duplicate detection, if required.
+
+					if (_topicBlk != null && !_topicBlk.IsClosedOrClosing)
+						await _topicBlk.SendAsync(message);
+
+					if (_queueBlk != null && !_queueBlk.IsClosedOrClosing)
+						await _queueBlk.SendAsync(message);
+
+				}
+			}));
+
+			_subscriptions.Add(_EventAggregator.Subscribe<Events.NewTransactionMatchEvent>(async o =>
+			{
+				var network = Waiters.GetWaiter(o.CryptoCode);
+				if (network == null)
+					return;
+
+				var chain = ChainProvider.GetChain(o.CryptoCode);
+				if (chain == null)
+					return;
+
+				var blockHeader = o.BlockId == null ? null : chain.GetBlock(o.BlockId);
+
+				var txe = new Models.NewTransactionEvent()
+				{
+					CryptoCode = o.CryptoCode,
+					DerivationStrategy = o.Match.DerivationStrategy,
+					BlockId = blockHeader?.Hash,
+					TransactionData = Utils.ToTransactionResult(true, chain, new[] { o.SavedTransaction }),
+					Inputs = o.Match.Inputs,
+					Outputs = o.Match.Outputs
+				};
+
+				string jsonMsg = txe.ToJson(_serializerSettings);
+				var bytes = Encoding.UTF8.GetBytes(jsonMsg);
+
+				var message = new Message(bytes);
+				message.MessageId = o.SavedTransaction.GetHashCode().ToString();
+				message.ContentType = txe.GetType().ToString();
+
+				if (_topicTran != null && !_topicTran.IsClosedOrClosing)
+					await _topicTran.SendAsync(message);
+
+				if (_queueTran != null && !_queueTran.IsClosedOrClosing)
+					await _queueTran.SendAsync(message);
+
+
+			}));
+
+			Logs.Configuration.LogInformation("Starting Azure Service Bus Message Broker");
+			return Task.CompletedTask;
+		}
+
+		public async Task StopAsync(CancellationToken cancellationToken)
+		{
+			Logs.Configuration.LogInformation("Stopping Azure Service Bus Message Broker");
+			_Disposed = true;
+			_subscriptions.Dispose();
+
+			if (_queueBlk!=null && !_queueBlk.IsClosedOrClosing)
+				await _queueBlk.CloseAsync();
+
+			if (_queueTran !=null &&  !_queueTran.IsClosedOrClosing)
+				await _queueBlk.CloseAsync();
+
+			if (_topicBlk != null && !_topicBlk.IsClosedOrClosing)
+				await _topicBlk.CloseAsync();
+
+			if (_topicTran != null && !_topicTran.IsClosedOrClosing)
+				await _topicTran.CloseAsync();
+		}
+
+		public ChainProvider ChainProvider
+		{
+			get; set;
+		}
+		public BitcoinDWaiters Waiters
+		{
+			get; set;
+		}
+	}
+}

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
 	<PackageReference Include="DBreeze" Version="1.87.0" />
 	  <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+	  <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
 	<PackageReference Include="NicolasDorier.CommandLine" Version="1.0.0.2" />
 	<PackageReference Include="NicolasDorier.CommandLine.Configuration" Version="1.0.0.3" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />

--- a/NBXplorer/Utils.cs
+++ b/NBXplorer/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using NBitcoin;
+using NBXplorer.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -59,6 +60,24 @@ namespace NBXplorer
 				result.Add(elem.Key);
 			}
 			return result;
+		}
+
+		public static TransactionResult ToTransactionResult(bool includeTransaction, SlimChain chain, Repository.SavedTransaction[] result)
+		{
+			var noDate = NBitcoin.Utils.UnixTimeToDateTime(0);
+			var oldest = result
+							.Where(o => o.Timestamp != noDate)
+							.OrderBy(o => o.Timestamp).FirstOrDefault() ?? result.First();
+
+			var confBlock = result
+						.Where(r => r.BlockHash != null)
+						.Select(r => chain.GetBlock(r.BlockHash))
+						.Where(r => r != null)
+						.FirstOrDefault();
+
+			var conf = confBlock == null ? 0 : chain.Height - confBlock.Height + 1;
+
+			return new TransactionResult() { Confirmations = conf, BlockId = confBlock?.Hash, Transaction = includeTransaction ? oldest.Transaction : null, Height = confBlock?.Height, Timestamp = oldest.Timestamp };
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -161,6 +161,37 @@ this should return a JSON payload e.g.
     "blockCount": 3
 }
 
+## Message Brokers
+### Azure Service Bus
+Support has been added for Azure Service Bus as a message broker. Currently 2 Queues and 2 Topics are supported
+
+### Queues
+* New Block
+* New Transaction
+
+### Topics
+* New Block
+* New Transaction
+
+
+Filters should be applied on the client, if required. 
+
+To activate Azure Service Bus Mesages you should add an Azure Service Bus Connection string to your config file or on the command line.
+
+* To use queues you should specify the queue names you wish to use
+* To use topics you should specify the topic names you wish to use
+
+You can use both queues and topics at the same time.
+
+#### Config Settings
+asbcnstr="[Your Azure Service Bus Connection string]"
+asbblockq="[Name of queue to send New Block message to]" 
+asbtranq="[Name of queue to send New Transaction message to]"
+asbblockt="[Name of topic to send New Block message to]" 
+asbtrant="[Name of queue to send New Transaction message to]" 
+
+Payloads are JSON and map to NewBlockEvent, NewTransactionEvent in the NBXplorer.Models namespace. There is no support in NBXplorer client for Azure Service Bus at the current time. You will need to use the Serializer in NBXplorer.Client to De-serialize the objects or then implement your own JSON de-serializers for the custom types used in the payload.
+
 #### Troubleshooting
 If you receive a 401 Unauthorized then your cookie data is not working. Check you are using the current cookie by opening the cookie file again - also check the date/time of the cookie file to ensure it is the latest cookie (generated when you launched NBXplorer).
 


### PR DESCRIPTION
- Added support for Azure Service Bus message broker as IHostedService. Supports both Queues and Topics.

- Uses same serialization as WebSocket

- Moved ToTransactionResult from MainController to Utils to aid re-use

- Added NewEventBase abstract base class with helper methods for Json conversion, updated NewEvent classes to derive from base.

- Added 2 Unit tests for Azure Service Bus and static TestConfig.cs to supply config settings

- Extended config settings to support Azure Service Bus config

- Removed some unused using statements

- Updated readme.md with information on Azure Service Bus Message Broker and how to configure

- All unit tests passing when active Service Bus connection string supplied.

- Azure service bus tests fail with no connection string message when connection string unavailable

- Rebased from latest Main branch, no merge conflicts