### PR TITLE
Hash Azure Serive Bus messageId and Validate

### DIFF
--- a/NBXplorer.Tests/TestConfig.cs
+++ b/NBXplorer.Tests/TestConfig.cs
@@ -7,7 +7,7 @@
 			get
 			{
 				//Put your service bus connection string here - requires READ / WRITE permissions
-				return "Endpoint=sb://prodwhalelend.servicebus.windows.net/;SharedAccessKeyName=nbxplorer;SharedAccessKey=p+QEv6F1E7znNuFYHtD6U86878mF7rx45NJBY7S3Jqs=";
+				return "";
 			}
 		}
 

--- a/NBXplorer.Tests/TestConfig.cs
+++ b/NBXplorer.Tests/TestConfig.cs
@@ -7,7 +7,7 @@
 			get
 			{
 				//Put your service bus connection string here - requires READ / WRITE permissions
-				return "";
+				return "Endpoint=sb://prodwhalelend.servicebus.windows.net/;SharedAccessKeyName=nbxplorer;SharedAccessKey=p+QEv6F1E7znNuFYHtD6U86878mF7rx45NJBY7S3Jqs=";
 			}
 		}
 

--- a/NBXplorer/MessageBrokers/AzureBroker.cs
+++ b/NBXplorer/MessageBrokers/AzureBroker.cs
@@ -7,11 +7,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Security.Cryptography;
 
 namespace NBXplorer.MessageBrokers
 {
 	public class AzureBroker : IBrokerClient
 	{
+		const int MaxMessageIdLength = 128;
+
 		public AzureBroker(ISenderClient client, JsonSerializerSettings serializerSettings)
 		{
 			Client = client;
@@ -33,7 +36,9 @@ namespace NBXplorer.MessageBrokers
 			string jsonMsg = transactionEvent.ToJson(SerializerSettings);
 			var bytes = UTF8.GetBytes(jsonMsg);
 			var message = new Message(bytes);
-			message.MessageId = $"{transactionEvent.DerivationStrategy.GetHash()}-{transactionEvent.TransactionData.Transaction.GetHash()}-{(transactionEvent.TransactionData.BlockId?.ToString() ?? string.Empty)}).ToString()";
+			string msgIdHash = HashMessageId($"{transactionEvent.DerivationStrategy.GetHash()}-{transactionEvent.TransactionData.Transaction.GetHash()}-{(transactionEvent.TransactionData.BlockId?.ToString() ?? string.Empty)}");
+			ValidateMessageId(msgIdHash);
+			message.MessageId = msgIdHash;
 			message.ContentType = transactionEvent.GetType().ToString();
 			await Client.SendAsync(message);
 		}
@@ -52,6 +57,24 @@ namespace NBXplorer.MessageBrokers
 		{
 			if(!Client.IsClosedOrClosing)
 				await Client.CloseAsync();
+		}
+
+		private string HashMessageId(string messageId)
+		{
+			HashAlgorithm algorithm = SHA256.Create();
+			return Encoding.UTF8.GetString( algorithm.ComputeHash(Encoding.UTF8.GetBytes(messageId)));
+		}
+
+		private void ValidateMessageId(string messageId)
+		{
+			if (string.IsNullOrEmpty(messageId) )
+			{
+				throw new ArgumentException("MessageIdIsNullOrEmpty");
+			}
+			else if (messageId.Length > MaxMessageIdLength)
+			{
+				throw new ArgumentException($"MessageIdIsOverMaxLength ({MaxMessageIdLength}) :  {messageId} ");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Azure Service Bus message id's cannot be null and must be 128 character string or less (based on C# client library validator).

The message Id is made by concatenating up to 3 hashes - this can result in > 128 chars. This PR creates a hash of the messageId to create a shorter messageId and also adds a validator to check the message id is valid before broadcasting.