### PR TITLE
Hash Azure Service Bus messageId and Validate

### DIFF
--- a/NBXplorer/MessageBrokers/AzureBroker.cs
+++ b/NBXplorer/MessageBrokers/AzureBroker.cs
@@ -7,11 +7,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Security.Cryptography;
 
 namespace NBXplorer.MessageBrokers
 {
 	public class AzureBroker : IBrokerClient
 	{
+		const int MaxMessageIdLength = 128;
+
 		public AzureBroker(ISenderClient client, JsonSerializerSettings serializerSettings)
 		{
 			Client = client;
@@ -33,7 +36,9 @@ namespace NBXplorer.MessageBrokers
 			string jsonMsg = transactionEvent.ToJson(SerializerSettings);
 			var bytes = UTF8.GetBytes(jsonMsg);
 			var message = new Message(bytes);
-			message.MessageId = $"{transactionEvent.DerivationStrategy.GetHash()}-{transactionEvent.TransactionData.Transaction.GetHash()}-{(transactionEvent.TransactionData.BlockId?.ToString() ?? string.Empty)}).ToString()";
+			string msgIdHash = HashMessageId($"{transactionEvent.DerivationStrategy.GetHash()}-{transactionEvent.TransactionData.Transaction.GetHash()}-{(transactionEvent.TransactionData.BlockId?.ToString() ?? string.Empty)}");
+			ValidateMessageId(msgIdHash);
+			message.MessageId = msgIdHash;
 			message.ContentType = transactionEvent.GetType().ToString();
 			await Client.SendAsync(message);
 		}
@@ -52,6 +57,24 @@ namespace NBXplorer.MessageBrokers
 		{
 			if(!Client.IsClosedOrClosing)
 				await Client.CloseAsync();
+		}
+
+		private string HashMessageId(string messageId)
+		{
+			HashAlgorithm algorithm = SHA256.Create();
+			return Encoding.UTF8.GetString( algorithm.ComputeHash(Encoding.UTF8.GetBytes(messageId)));
+		}
+
+		private void ValidateMessageId(string messageId)
+		{
+			if (string.IsNullOrEmpty(messageId) )
+			{
+				throw new ArgumentException("MessageIdIsNullOrEmpty");
+			}
+			else if (messageId.Length > MaxMessageIdLength)
+			{
+				throw new ArgumentException($"MessageIdIsOverMaxLength ({MaxMessageIdLength}) :  {messageId} ");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Azure service bus message Id must be 128 characters or less. It is possible that the concatenated transaction/block/strategy hashes can have a length > 128 which causes an exception in the service bus client library. 

Fix - hash the hashes and validate the message id before attempting to send.