### PR TITLE
Add BitCore BTX support

### DIFF
--- a/NBXplorer.Client/NBXplorerNetworkProvider.Bitcore.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Bitcore.cs
@@ -1,0 +1,23 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NBXplorer
+{
+	public partial class NBXplorerNetworkProvider
+	{
+		private void InitBitcore(NetworkType networkType)
+		{
+			Add(new NBXplorerNetwork(NBitcoin.Altcoins.Bitcore.Instance, networkType)
+			{
+				MinRPCVersion = 150100
+			});
+		}
+
+		public NBXplorerNetwork GetBTX()
+		{
+			return GetFromCryptoCode(NBitcoin.Altcoins.Bitcore.Instance.CryptoCode);
+		}
+	}
+}

--- a/NBXplorer.Client/NBXplorerNetworkProvider.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.cs
@@ -10,6 +10,7 @@ namespace NBXplorer
 		public NBXplorerNetworkProvider(NetworkType networkType)
 		{
 			InitBitcoin(networkType);
+			InitBitcore(networkType);
 			InitLitecoin(networkType);
 			InitDogecoin(networkType);
 			InitBCash(networkType);

--- a/NBXplorer.Tests/ServerTester.Environment.cs
+++ b/NBXplorer.Tests/ServerTester.Environment.cs
@@ -55,13 +55,13 @@ namespace NBXplorer.Tests
 			//nodeDownloadData = NodeDownloadData.Groestlcoin.v2_16_0;
 			//Network = NBitcoin.Altcoins.Groestlcoin.Instance.Regtest;
 
-			CryptoCode = "BTX";
-			nodeDownloadData = NodeDownloadData.Bitcore.v0_15_2;
-			Network = NBitcoin.Altcoins.Bitcore.Instance.Regtest;
+			//CryptoCode = "BTX";
+			//nodeDownloadData = NodeDownloadData.Bitcore.v0_15_2;
+			//Network = NBitcoin.Altcoins.Bitcore.Instance.Regtest;
 
-			//CryptoCode = "BTC";
-			//nodeDownloadData = NodeDownloadData.Bitcoin.v0_17_0;
-			//Network = NBitcoin.Network.RegTest;
+			CryptoCode = "BTC";
+			nodeDownloadData = NodeDownloadData.Bitcoin.v0_17_0;
+			Network = NBitcoin.Network.RegTest;
 		}
 	}
 }

--- a/NBXplorer.Tests/ServerTester.Environment.cs
+++ b/NBXplorer.Tests/ServerTester.Environment.cs
@@ -55,9 +55,13 @@ namespace NBXplorer.Tests
 			//nodeDownloadData = NodeDownloadData.Groestlcoin.v2_16_0;
 			//Network = NBitcoin.Altcoins.Groestlcoin.Instance.Regtest;
 
-			CryptoCode = "BTC";
-			nodeDownloadData = NodeDownloadData.Bitcoin.v0_17_0;
-			Network = NBitcoin.Network.RegTest;
+			CryptoCode = "BTX";
+			nodeDownloadData = NodeDownloadData.Bitcore.v0_15_2;
+			Network = NBitcoin.Altcoins.Bitcore.Instance.Regtest;
+
+			//CryptoCode = "BTC";
+			//nodeDownloadData = NodeDownloadData.Bitcoin.v0_17_0;
+			//Network = NBitcoin.Network.RegTest;
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It currently supports:
 * BCash (also known as Bitcoin Cash)
 * BGold (also known as Bitcoin Gold)
 * Bitcoin
+* Bitcore
 * Dash
 * Dogecoin
 * Feathercoin


### PR DESCRIPTION
- Support for NBitcoin available: [Pull 569](https://github.com/MetacoSA/NBitcoin/pull/569) and [Pull 518](https://github.com/MetacoSA/NBitcoin/pull/518)

- Tests executed with NBitcoin.TestFramework" Version="1.6.19" - [NBXplorer.Tests.csproj](https://github.com/dgarage/NBXplorer/blob/master/NBXplorer.Tests/NBXplorer.Tests.csproj) updated during testing

- Tests _CanSendAzureServiceBusNewTransactionEventMessage_ and _CanSendAzureServiceBusNewBlockEventMessage_ failed because AzureService was not configured