### PR TITLE
Hint in the Fees-Example-URL that crypto-code should be upper-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You can test the NBXplorer API quickly and easily using Postman as follows :
 
 You are now ready to test the API - it is easiest to start with something simple such as the fees endpoint e.g.
 
-```http://localhost:24444/v1/cryptos/btc/fees/3```
+```http://localhost:24444/v1/cryptos/BTC/fees/3```
 
 this should return a JSON payload e.g.
 


### PR DESCRIPTION
The `/fees` call seems to accept both, but other (like `GET /v1/cryptos/BTC/derivations/xpub...-[p2sh]/transactions`) only accept it in uppercase (because how `DerivationStrategyModelBinder` parses it)