### PR TITLE
make cryptoCode uppercase on GetWaiter

### DIFF
--- a/NBXplorer/BitcoinDWaiter.cs
+++ b/NBXplorer/BitcoinDWaiter.cs
@@ -83,7 +83,7 @@ namespace NBXplorer
 		}
 		public BitcoinDWaiter GetWaiter(string cryptoCode)
 		{
-			_Waiters.TryGetValue(cryptoCode, out BitcoinDWaiter waiter);
+			_Waiters.TryGetValue(cryptoCode.ToUpperInvariant(), out BitcoinDWaiter waiter);
 			return waiter;
 		}
 


### PR DESCRIPTION
some uppercase are already fixed with commit: 17dfb21ff967d058da6afc6ad36f6cd7727a61c0
but not `/v1/cryptos/{cryptoCode}/rescan`