### PR TITLE
3 launch project configurations for different coins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
 
 *_i.c
 *_p.c

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -24,7 +24,7 @@
 
     "NBXplorer - DASH on Testnet": {
       "commandName": "Project",
-      "commandLineArgs": "--chains=dash --network=test --dashrpcuser=myuser --dashrpcpassword=mypassword",
+      "commandLineArgs": "--chains=dash --network=testnet",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:4771/",
+      "sslPort": 0
+    }
+  },
+  
+  "profiles": {
+    "NBXplorer - BTC on Mainnet": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:4774/"
+    },
+	
+    "NBXplorer - BTC+LTC on Regtest": {
+      "commandName": "Project",
+      "commandLineArgs": "--chains=btc,ltc --network=regtest",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:4774/"
+	},
+	
+    "NBXplorer - DASH on Testnet": {
+      "commandName": "Project",
+      "commandLineArgs": "--chains=dash --network=test --dashrpcuser=myuser --dashrpcpassword=mypassword",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:4774/"
+    }
+  }
+}

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NBXplorer - BTC on Mainnet": {
       "commandName": "Project",
-      "commandLineArgs": "--btcrpcuser=myuser --btcrpcpassword=mypassword",
+      "commandLineArgs": "",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -13,7 +13,7 @@
 
     "NBXplorer - BTC+LTC on Regtest": {
       "commandName": "Project",
-      "commandLineArgs": "--chains=btc,ltc --network=regtest --btcrpcuser=myuser --btcrpcpassword=mypassword --ltcrpcuser=myuser --ltcrpcpassword=mypassword",
+      "commandLineArgs": "--chains=btc,ltc --network=regtest",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -15,9 +15,10 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:4774/"
+      "applicationUrl": "http://localhost:4774",
+      "launchUrl": "v1/cryptos/btc/status"
     },
-	
+
     "NBXplorer - BTC+LTC on Regtest": {
       "commandName": "Project",
       "commandLineArgs": "--chains=btc,ltc --network=regtest",
@@ -25,9 +26,10 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:4774/"
-	},
-	
+      "applicationUrl": "http://localhost:4774",
+      "launchUrl": "v1/cryptos/ltc/status"
+    },
+
     "NBXplorer - DASH on Testnet": {
       "commandName": "Project",
       "commandLineArgs": "--chains=dash --network=test --dashrpcuser=myuser --dashrpcpassword=mypassword",
@@ -35,7 +37,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:4774/"
+      "applicationUrl": "http://localhost:4774",
+      "launchUrl": "v1/cryptos/dash/status"
     }
   }
 }

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -1,13 +1,4 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:4771/",
-      "sslPort": 0
-    }
-  },
-  
   "profiles": {
     "NBXplorer - BTC on Mainnet": {
       "commandName": "Project",

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -11,6 +11,7 @@
   "profiles": {
     "NBXplorer - BTC on Mainnet": {
       "commandName": "Project",
+      "commandLineArgs": "--btcrpcuser=myuser --btcrpcpassword=mypassword",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -21,7 +22,7 @@
 
     "NBXplorer - BTC+LTC on Regtest": {
       "commandName": "Project",
-      "commandLineArgs": "--chains=btc,ltc --network=regtest",
+      "commandLineArgs": "--chains=btc,ltc --network=regtest --btcrpcuser=myuser --btcrpcpassword=mypassword --ltcrpcuser=myuser --ltcrpcpassword=mypassword",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Example, if you have ltc node and btc node on regtest (default configuration), a
 
 ## How to use the API?
 
-Check [the documentation](docs/API.md), you can then use any client library:
+Check [the API documentation](docs/API.md), you can then use any client library:
 * [NBXplorer.NodeJS](https://github.com/junderw/NBXplorer.NodeJS) for NodeJS clients.
 * [NBXplorer.Client](https://www.nuget.org/packages/NBxplorer.Client) for .NET clients.
 
@@ -133,10 +133,12 @@ Please note that NBXplorer uses cookie authentication by default. If you run you
 If you run the node(s) using the GUI versions, like Bitcoin\Litecoin\Dash Core Qt with the `-server` parameter while you set the rpcusername and rpcpassword in their `.conf` files, you must set those values for every crypto you are planning to support. 
 See samples below.
 
-#### Run from source (.NET Core SDK required)
-```dotnet run -p .\NBXplorer\NBXplorer.csproj <parameters>```
+#### Run from source (requires .NET Core SDK)
+You should use `run.ps1` (Windows) or `run.sh` (Linux) to execute NBXplorer, but you can also execute it manually with the following command:
+```dotnet run --no-launch-profile -p .\NBXplorer\NBXplorer.csproj -- <parameters>```
 
-#### Run using built DLL (.NET Core Runtime required)
+#### Run using built DLL (requires .NET Core Runtime only)
+If you already have a compiled DLL, you can run the compiled executable with the following command:
 ```dotnet NBXplorer.dll <parameters>```
 
 #### Sample parameters

--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ If you need to see old payments, you need to configure `startheight` to a specif
 ### Using Postman
 [Postman](https://www.getpostman.com) is a useful tool for testing and experimenting with REST API's. 
 
-You can test the [NBXplorer API](docs/API.md) quickly and easily using Postman as follows :
-* Assumption: you are using the default Cookie Auth , you are running NBXplorer on the same machine as your BTC (or other supported crypto) node or NBXplorer can access the blockchain data files.
-* Run NBXplorer and locate you cookie file - note NBXplorer will generate a new Cookie file each time it runs
+You can test the [NBXplorer API](docs/API.md) quickly and easily using Postman.
+
+If you use cookie authentication (enabled by default) in your locally run NBXplorer, you need to set that up in Postman:
+* Run NBXplorer and locate you cookie file (NBXplorer will generate a new Cookie file each time it runs in [its default data folder](docs/API.md#authentication))
 * In Postman create a new GET API test
 * In Authorization select *Basic Auth*, you should see 2 input boxes for username and password
 * Open your cookie file with a text editor e.g. Notepad on windows . You should see a cookie string e.g. `__cookie__:0ff9cd83a5ac7c19a6b56a3d1e7a5c96e113d42dba7720a1f72a3a5e8c4b6c66`
@@ -189,6 +190,13 @@ You can test the [NBXplorer API](docs/API.md) quickly and easily using Postman a
 * Paste the Hex string (after the : ) into the password box
 * Click the Update Request button in Postman - this will force Postman to generate the correct HTTP headers based on your cookie details
 * You should now see a new entry in the Headers section with a Key of *Authorization* and Value of *Basic xxxxxxxxx* where the string after `Basic` will be your Base64 encoded username and password.
+* Enter the API URL you are going to test
+
+You can also disable authentication in NBXplorer for testing with the `--noauth` parameter. This makes testing quicker:
+* Run NBXplorer with the `--noauth` parameter
+* In Postman create a new GET API test
+* In Authorization select *No Auth*
+* Enter the API URL you are going to test
 
 You are now ready to test the API - it is easiest to start with something simple such as the fees endpoint e.g.
 

--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ If you run the node(s) using the GUI versions, like Bitcoin\Litecoin\Dash Core Q
 See samples below.
 
 #### Run from source (.NET Core SDK required)
-```dotnet run NBXplorer.dll <parameters>```
+```dotnet run -p .\NBXplorer\NBXplorer.csproj <parameters>```
 
 #### Run using built DLL (.NET Core Runtime required)
 ```dotnet NBXplorer.dll <parameters>```
 
 #### Sample parameters
 Running NBXplorer HTTP server on port 20300, connecting to the BTC mainnet node locally.
-```--port=20300 --network=mainnet --nodeendpoint=127.0.0.1:32939```
+```--port=20300 --network=mainnet --btcnodeendpoint=127.0.0.1:32939```
 
 Running NBXplorer on testnet, supporting Bitcoin, Litecoin and Dash, using cookie authentication for BTC and LTC, and RPC username and password for Dash, connecting to all of them locally. 
 ```--chains=btc,ltc,dash --network=testnet --dashrpcuser=myuser --dashrpcpassword=mypassword```

--- a/README.md
+++ b/README.md
@@ -129,13 +129,26 @@ The default configuration assumes `mainnet` with only `btc` chain supported, and
 You can change the location of the configuration file with the `--conf=pathToConf` command line argument.
 
 ### Command line parameters
+Please note that NBXplorer uses cookie authentication by default. If you run your Bitcoin/Litecoin/Dash nodes using their daemon (like `bitcoind`, `litecoind` or `dashd`), they generate a new cookie every time you start them, and that should work without any extra configuration. 
+If you run the node(s) using the GUI versions, like Bitcoin\Litecoin\Dash Core Qt with the `-server` parameter while you set the rpcusername and rpcpassword in their `.conf` files, you must set those values for every crypto you are planning to support. 
+See samples below.
 
-#### From Source (.NET Core SDK required)
-The same settings as above, e.g.
-```dotnet run NBXplorer.dll --port=20300 --network=mainnet --nodeendpoint=127.0.0.1:32939```
+#### Run from source (.NET Core SDK required)
+```dotnet run NBXplorer.dll <parameters>```
 
-#### From Built DLL (.NET Core Runtime required)
-```dotnet NBXplorer.dll --port=20300 --network=mainnet --nodeendpoint=127.0.0.1:32939```
+#### Run using built DLL (.NET Core Runtime required)
+```dotnet NBXplorer.dll <parameters>```
+
+#### Sample parameters
+Running NBXplorer HTTP server on port 20300, connecting to the BTC mainnet node locally.
+```--port=20300 --network=mainnet --nodeendpoint=127.0.0.1:32939```
+
+Running NBXplorer on testnet, supporting Bitcoin, Litecoin and Dash, using cookie authentication for BTC and LTC, and RPC username and password for Dash, connecting to all of them locally. 
+```--chains=btc,ltc,dash --network=testnet --dashrpcuser=myuser --dashrpcpassword=mypassword```
+
+Running NBXplorer with a BTC rescan from January 1st of 2019.
+```--network=mainnet --btcstartheight=556452 --btcrescan```
+
 
 ### Environment variables
 
@@ -167,7 +180,7 @@ If you need to see old payments, you need to configure `startheight` to a specif
 ### Using Postman
 [Postman](https://www.getpostman.com) is a useful tool for testing and experimenting with REST API's. 
 
-You can test the NBXplorer API quickly and easily using Postman as follows :
+You can test the [NBXplorer API](docs/API.md) quickly and easily using Postman as follows :
 * Assumption: you are using the default Cookie Auth , you are running NBXplorer on the same machine as your BTC (or other supported crypto) node or NBXplorer can access the blockchain data files.
 * Run NBXplorer and locate you cookie file - note NBXplorer will generate a new Cookie file each time it runs
 * In Postman create a new GET API test

--- a/README.md
+++ b/README.md
@@ -146,9 +146,6 @@ Running NBXplorer HTTP server on port 20300, connecting to the BTC mainnet node 
 Running NBXplorer on testnet, supporting Bitcoin, Litecoin and Dash, using cookie authentication for BTC and LTC, and RPC username and password for Dash, connecting to all of them locally. 
 ```--chains=btc,ltc,dash --network=testnet --dashrpcuser=myuser --dashrpcpassword=mypassword```
 
-Running NBXplorer with a BTC rescan from January 1st of 2019.
-```--network=mainnet --btcstartheight=556452 --btcrescan```
-
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You should use `run.ps1` (Windows) or `run.sh` (Linux) to execute NBXplorer, but
 ```dotnet run --no-launch-profile -p .\NBXplorer\NBXplorer.csproj -- <parameters>```
 
 #### Run using built DLL (requires .NET Core Runtime only)
-If you already have a compiled DLL, you can run the compiled executable with the following command:
+If you already have a compiled DLL, you can run the executable with the following command:
 ```dotnet NBXplorer.dll <parameters>```
 
 #### Sample parameters


### PR DESCRIPTION
Added 3 launch configs to the NBXplorer:
"NBXplorer - BTC on Mainnet" -> run NBXplorer with the default arguments
"NBXplorer - BTC+LTC on Regtest" -> run NBXplorer with the BTC+LTC config as in [README.md](https://github.com/dgarage/NBXplorer#how-to-build-and-run)
"NBXplorer - DASH on Testnet" -> run NBXplorer with default DASH Testnet settings

![image](https://user-images.githubusercontent.com/910321/63927717-8cccc280-ca4e-11e9-80ad-f19746d35f08.png)


I think they are useful examples for new contributors like me, it helps to understand the typical parameters of NBXplorer and their effects.

All 3 open the status page of BTC, LTC or DASH by default. (Although we must use basic authentication to get the results so the page itself will be an empty 401 page.)

A tested the cases with Postman.