### PR TITLE
Increase timeout for chain loading from cache

### DIFF
--- a/NBXplorer.Client/NBXplorerNetwork.cs
+++ b/NBXplorer.Client/NBXplorerNetwork.cs
@@ -77,6 +77,12 @@ namespace NBXplorer
 			set;
 		} = TimeSpan.FromMinutes(15);
 
+		public TimeSpan ChainCacheLoadingTimeout
+		{
+			get;
+			set;
+		} = TimeSpan.FromSeconds(30);
+
 		/// <summary>
 		/// Minimum blocks to keep if pruning is activated
 		/// </summary>

--- a/NBXplorer.Client/NBXplorerNetworkProvider.Dogecoin.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Dogecoin.cs
@@ -13,6 +13,7 @@ namespace NBXplorer
 			{
 				MinRPCVersion = 140200,
 				ChainLoadingTimeout = TimeSpan.FromHours(1),
+				ChainCacheLoadingTimeout = TimeSpan.FromMinutes(2),
 				SupportCookieAuthentication = false
 			});
 		}

--- a/NBXplorer/BitcoinDWaiter.cs
+++ b/NBXplorer/BitcoinDWaiter.cs
@@ -449,7 +449,7 @@ namespace NBXplorer
 									throw;
 								}
 								handshaked = true;
-								var loadChainTimeout = _Network.NBitcoinNetwork.NetworkType == NetworkType.Regtest ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(15);
+								var loadChainTimeout = _Network.NBitcoinNetwork.NetworkType == NetworkType.Regtest ? TimeSpan.FromSeconds(5) : _Network.ChainCacheLoadingTimeout;
 								if (_Chain.Height < 5)
 									loadChainTimeout = TimeSpan.FromDays(7); // unlimited
 								Logs.Configuration.LogInformation($"{_Network.CryptoCode}: Loading chain from node");


### PR DESCRIPTION
Increased timeout for chain loading from cache as this can cause significant downtime for chains with a lot of blocks like Dogecoin after restart.