### PR TITLE
Always reuse DerivationStrategyFactory from the NBX Network 

### DIFF
--- a/NBXplorer.Client/ExplorerClient.cs
+++ b/NBXplorer.Client/ExplorerClient.cs
@@ -84,7 +84,7 @@ namespace NBXplorer
 			_Network = network;
 			Serializer = new Serializer(network);
 			_CryptoCode = _Network.CryptoCode;
-			_Factory = new DerivationStrategy.DerivationStrategyFactory(Network.NBitcoinNetwork);
+			_Factory = Network.DerivationStrategyFactory;
 			SetCookieAuth(network.DefaultSettings.DefaultCookieFile);
 		}
 

--- a/NBXplorer.Client/JsonConverters/CachedSerializer.cs
+++ b/NBXplorer.Client/JsonConverters/CachedSerializer.cs
@@ -52,12 +52,12 @@ namespace NBXplorer.JsonConverters
 				return Converter.CanConvert(objectType);
 			}
 		}
-		public CachedSerializer(Network network)
+		public CachedSerializer(NBXplorerNetwork network)
 		{
 			if (network == null)
 				throw new ArgumentNullException(nameof(network));
-			cachedConverter.Add(new CachedConverter(new BitcoinStringJsonConverter(network)));
-			cachedConverter.Add(new CachedConverter(new DerivationStrategyJsonConverter(new DerivationStrategy.DerivationStrategyFactory(network))));
+			cachedConverter.Add(new CachedConverter(new BitcoinStringJsonConverter(network.NBitcoinNetwork)));
+			cachedConverter.Add(new CachedConverter(new DerivationStrategyJsonConverter(network.DerivationStrategyFactory)));
 			cachedConverter.Add(new CachedConverter(new TrackedSourceJsonConverter(network)));
 		}
 		public override bool CanConvert(Type objectType)

--- a/NBXplorer.Client/JsonConverters/TrackedSourceJsonConverter.cs
+++ b/NBXplorer.Client/JsonConverters/TrackedSourceJsonConverter.cs
@@ -11,12 +11,12 @@ namespace NBXplorer.JsonConverters
 {
 	public class TrackedSourceJsonConverter : JsonConverter
 	{
-		public TrackedSourceJsonConverter(Network network)
+		public TrackedSourceJsonConverter(NBXplorerNetwork network)
 		{
 			Network = network;
 		}
 
-		public Network Network { get; }
+		public NBXplorerNetwork Network { get; }
 
 		public override bool CanConvert(Type objectType)
 		{

--- a/NBXplorer.Client/Models/TrackedSource.cs
+++ b/NBXplorer.Client/Models/TrackedSource.cs
@@ -10,7 +10,7 @@ namespace NBXplorer.Models
 {
 	public abstract class TrackedSource
 	{
-		public static bool TryParse(string str, out TrackedSource trackedSource, Network network)
+		public static bool TryParse(string str, out TrackedSource trackedSource, NBXplorerNetwork network)
 		{
 			if (str == null)
 				throw new ArgumentNullException(nameof(str));
@@ -26,7 +26,7 @@ namespace NBXplorer.Models
 			}
 			else if (strSpan.StartsWith("ADDRESS:".AsSpan(), StringComparison.Ordinal))
 			{
-				if (!AddressTrackedSource.TryParse(strSpan, out var addressTrackedSource, network))
+				if (!AddressTrackedSource.TryParse(strSpan, out var addressTrackedSource, network.NBitcoinNetwork))
 					return false;
 				trackedSource = addressTrackedSource;
 			}
@@ -154,7 +154,7 @@ namespace NBXplorer.Models
 
 		public DerivationStrategy.DerivationStrategyBase DerivationStrategy { get; }
 
-		public static bool TryParse(ReadOnlySpan<char> strSpan, out DerivationSchemeTrackedSource derivationSchemeTrackedSource, Network network)
+		public static bool TryParse(ReadOnlySpan<char> strSpan, out DerivationSchemeTrackedSource derivationSchemeTrackedSource, NBXplorerNetwork network)
 		{
 			if (strSpan == null)
 				throw new ArgumentNullException(nameof(strSpan));
@@ -165,7 +165,7 @@ namespace NBXplorer.Models
 				return false;
 			try
 			{
-				var factory = new DerivationStrategy.DerivationStrategyFactory(network);
+				var factory = network.DerivationStrategyFactory;
 				var derivationScheme = factory.Parse(strSpan.Slice("DERIVATIONSCHEME:".Length).ToString());
 				derivationSchemeTrackedSource = new DerivationSchemeTrackedSource(derivationScheme);
 				return true;

--- a/NBXplorer.Client/NBXplorerNetwork.cs
+++ b/NBXplorer.Client/NBXplorerNetwork.cs
@@ -11,7 +11,8 @@ namespace NBXplorer
 {
 	public class NBXplorerNetwork
 	{
-		public NBXplorerNetwork(INetworkSet networkSet, NBitcoin.NetworkType networkType)
+		public NBXplorerNetwork(INetworkSet networkSet, NetworkType networkType,
+			DerivationStrategyFactory derivationStrategyFactory = null)
 		{
 			NBitcoinNetwork = networkSet.GetNetwork(networkType);
 			CryptoCode = networkSet.CryptoCode;
@@ -102,6 +103,11 @@ namespace NBXplorer
 		public override string ToString()
 		{
 			return CryptoCode.ToString();
+		}
+		
+		public virtual ExplorerClient CreateExplorerClient(Uri uri)
+		{
+			return new ExplorerClient(this, uri);
 		}
 	}
 }

--- a/NBXplorer.Client/NBXplorerNetwork.cs
+++ b/NBXplorer.Client/NBXplorerNetwork.cs
@@ -17,6 +17,7 @@ namespace NBXplorer
 			NBitcoinNetwork = networkSet.GetNetwork(networkType);
 			CryptoCode = networkSet.CryptoCode;
 			DefaultSettings = NBXplorerDefaultSettings.GetDefaultSettings(networkType);
+			DerivationStrategyFactory = derivationStrategyFactory;
 		}
 		public Network NBitcoinNetwork
 		{

--- a/NBXplorer.Client/NBXplorerNetworkProvider.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.cs
@@ -29,7 +29,7 @@ namespace NBXplorer
 			InitChaincoin(networkType);
 			foreach(var chain in _Networks.Values)
 			{
-				chain.DerivationStrategyFactory = new DerivationStrategy.DerivationStrategyFactory(chain.NBitcoinNetwork);
+				chain.DerivationStrategyFactory ??= new DerivationStrategy.DerivationStrategyFactory(chain.NBitcoinNetwork);
 			}
 		}
 

--- a/NBXplorer.Client/Serializer.cs
+++ b/NBXplorer.Client/Serializer.cs
@@ -10,19 +10,13 @@ namespace NBXplorer
 	public class Serializer
 	{
 
-		private readonly Network _Network;
-		public Network Network
-		{
-			get
-			{
-				return _Network;
-			}
-		}
+		private readonly NBXplorerNetwork _Network;
+		public Network Network => _Network?.NBitcoinNetwork;
 
 		public JsonSerializerSettings Settings { get; } = new JsonSerializerSettings();
 		public Serializer(NBXplorerNetwork network)
 		{
-			_Network = network?.NBitcoinNetwork;
+			_Network = network;
 			ConfigureSerializer(Settings);
 		}
 
@@ -33,7 +27,7 @@ namespace NBXplorer
 			NBitcoin.JsonConverters.Serializer.RegisterFrontConverters(settings, Network);
 			if (Network != null)
 			{
-				settings.Converters.Insert(0, new JsonConverters.CachedSerializer(Network));
+				settings.Converters.Insert(0, new JsonConverters.CachedSerializer(_Network));
 			}
 			settings.Converters.Insert(0, new JsonConverters.FeeRateJsonConverter());
 		}

--- a/NBXplorer.Tests/ServerTester.Environment.cs
+++ b/NBXplorer.Tests/ServerTester.Environment.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using NBitcoin;
 
 namespace NBXplorer.Tests
 {
@@ -76,7 +77,7 @@ namespace NBXplorer.Tests
 
 			CryptoCode = "BTC";
 			nodeDownloadData = NodeDownloadData.Bitcoin.v0_18_0;
-			Network = NBitcoin.Network.RegTest;
+			NBXplorerNetwork = new NBXplorerNetwork(Network.RegTest.NetworkSet, NetworkType.Regtest);
 		}
 	}
 }

--- a/NBXplorer.Tests/ServerTester.cs
+++ b/NBXplorer.Tests/ServerTester.cs
@@ -137,12 +137,11 @@ namespace NBXplorer.Tests
 				.Build();
 
 			RPC = ((RPCClientProvider)Host.Services.GetService(typeof(RPCClientProvider))).GetRPCClient(CryptoCode);
-			var nbxnetwork = ((NBXplorerNetworkProvider)Host.Services.GetService(typeof(NBXplorerNetworkProvider))).GetFromCryptoCode(CryptoCode);
-			Network = nbxnetwork.NBitcoinNetwork;
+			NBXplorerNetwork = ((NBXplorerNetworkProvider)Host.Services.GetService(typeof(NBXplorerNetworkProvider))).GetFromCryptoCode(CryptoCode);
 			var conf = (ExplorerConfiguration)Host.Services.GetService(typeof(ExplorerConfiguration));
 			Host.Start();
 			Configuration = conf;
-			_Client = new ExplorerClient(nbxnetwork, Address);
+			_Client = NBXplorerNetwork.CreateExplorerClient(Address);
 			_Client.SetCookieAuth(Path.Combine(conf.DataDir, ".cookie"));
 			Notifications = _Client.CreateLongPollingNotificationSession();
 		}
@@ -220,6 +219,13 @@ namespace NBXplorer.Tests
 		}
 
 		public Network Network
+		{
+			get
+			{
+				return NBXplorerNetwork.NBitcoinNetwork;
+			}
+		}
+		public NBXplorerNetwork NBXplorerNetwork
 		{
 			get;
 			internal set;
@@ -325,7 +331,7 @@ namespace NBXplorer.Tests
 			pubKey = pubKey ?? new ExtKey().Neuter();
 			string suffix = this.RPC.Capabilities.SupportSegwit ? "" : "-[legacy]";
 			suffix += p2sh ? "-[p2sh]" : "";
-			return new DerivationStrategyFactory(this.Network).Parse($"{pubKey.ToString(this.Network)}{suffix}");
+			return NBXplorerNetwork.DerivationStrategyFactory.Parse($"{pubKey.ToString(this.Network)}{suffix}");
 		}
 
 		public bool RPCStringAmount

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -27,6 +27,11 @@ namespace NBXplorer.Tests
 			Logs.Tester = new XUnitLog(helper) { Name = "Tests" };
 			Logs.LogProvider = new XUnitLogProvider(helper);
 		}
+		
+		private NBXplorerNetwork GetNetwork(Network network)
+		{
+			return new NBXplorerNetwork(network.NetworkSet, network.NetworkType, new DerivationStrategyFactory(network));
+		}
 
 		[Fact]
 		public void CanFixedSizeCache()
@@ -1712,7 +1717,7 @@ namespace NBXplorer.Tests
 			using (var tester = ServerTester.Create())
 			{
 				var extkey = new BitcoinExtKey(new ExtKey(), tester.Network);
-				var pubkey = new DerivationStrategyFactory(extkey.Network).Parse($"{extkey.Neuter()}-[legacy]");
+				var pubkey = tester.NBXplorerNetwork.DerivationStrategyFactory.Parse($"{extkey.Neuter()}-[legacy]");
 				Logs.Tester.LogInformation("Let's make a tracked address from hd pubkey 0/0");
 				var key = extkey.ExtKey.Derive(new KeyPath("0/0")).PrivateKey;
 				var address = key.PubKey.GetAddress(ScriptPubKeyType.Legacy, tester.Network);
@@ -1762,7 +1767,7 @@ namespace NBXplorer.Tests
 
 				Logs.Tester.LogInformation("Trying to send to a single address from a tracked extkey");
 				var extkey2 = new BitcoinExtKey(new ExtKey(), tester.Network);
-				var pubkey2 = new DerivationStrategyFactory(extkey.Network).Parse($"{extkey.Neuter()}-[legacy]");
+				var pubkey2 = tester.NBXplorerNetwork.DerivationStrategyFactory.Parse($"{extkey.Neuter()}-[legacy]");
 				tester.Client.Track(pubkey2);
 				var txId = tester.SendToAddress(pubkey2.GetDerivation(new KeyPath("0/0")).ScriptPubKey, Money.Coins(1.0m));
 				tester.Notifications.WaitForTransaction(pubkey2, txId);
@@ -2368,7 +2373,7 @@ namespace NBXplorer.Tests
 		public void CanTopologicalSortRecords()
 		{
 			var key = new BitcoinExtKey(new ExtKey(), Network.RegTest);
-			var pubkey = new DerivationStrategyFactory(Network.RegTest).Parse($"{key.Neuter().ToString()}");
+			var pubkey = GetNetwork(Network.RegTest).DerivationStrategyFactory.Parse($"{key.Neuter().ToString()}");
 			var trackedSource = new DerivationSchemeTrackedSource(pubkey);
 
 			// The topological sorting should always return the most buried transactions first

--- a/NBXplorer/BitcoinDWaiter.cs
+++ b/NBXplorer/BitcoinDWaiter.cs
@@ -494,7 +494,7 @@ namespace NBXplorer
 							}
 							catch (OperationCanceledException) when (!handshaked && handshakeTimeout.IsCancellationRequested)
 							{
-								Logs.Explorer.LogWarning($"{Network.CryptoCode}: The initial hanshake failed, your NBXplorer server might not be whitelisted by your node," +
+								Logs.Explorer.LogWarning($"{Network.CryptoCode}: The initial handshake failed, your NBXplorer server might not be whitelisted by your node," +
 										$" if your bitcoin node is on the same machine as NBXplorer, you should add \"whitelist=127.0.0.1\" to the configuration file of your node. (Or use whitebind)");
 								throw;
 							}

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -366,7 +366,7 @@ namespace NBXplorer.Controllers
 								{
 									foreach (var derivation in r.DerivationSchemes)
 									{
-										var parsed = new DerivationStrategyFactory(network.NBitcoinNetwork).Parse(derivation);
+										var parsed = network.DerivationStrategyFactory.Parse(derivation);
 										listenedDerivations.TryAdd((network.NBitcoinNetwork, parsed), parsed);
 									}
 								}
@@ -390,7 +390,7 @@ namespace NBXplorer.Controllers
 								{
 									foreach (var trackedSource in r.TrackedSources)
 									{
-										if (TrackedSource.TryParse(trackedSource, out var parsed, network.NBitcoinNetwork))
+										if (TrackedSource.TryParse(trackedSource, out var parsed, network))
 											listenedTrackedSource.TryAdd((network.NBitcoinNetwork, parsed), parsed);
 									}
 								}

--- a/NBXplorer/ModelBinders/DerivationStrategyModelBinder.cs
+++ b/NBXplorer/ModelBinders/DerivationStrategyModelBinder.cs
@@ -42,7 +42,7 @@ namespace NBXplorer.ModelBinders
 			var network = networkProvider.GetFromCryptoCode((cryptoCode ?? "BTC"));
 			try
 			{
-				var data = new DerivationStrategy.DerivationStrategyFactory(network.NBitcoinNetwork).Parse(key);
+				var data = network.DerivationStrategyFactory.Parse(key);
 				if(!bindingContext.ModelType.IsInstanceOfType(data))
 				{
 					throw new FormatException("Invalid destination type");


### PR DESCRIPTION
Always reuse DerivationStrategyFactory from the NBX Network instead of creating a new instance

If there is an NBX network that has its own derived factory, NBX would fail in various places to use that correct type. This fixes that but also makes sense beyond that. Also included here: typo fix in a log + helper method to create `ExplorerClient` from the NBX network directly