### PR TITLE
Add CryptoCode to Azure message properties

### DIFF
--- a/NBXplorer/MessageBrokers/AzureBroker.cs
+++ b/NBXplorer/MessageBrokers/AzureBroker.cs
@@ -37,6 +37,7 @@ namespace NBXplorer.MessageBrokers
 			ValidateMessageId(msgIdHash);
 			message.MessageId = msgIdHash;
 			message.ContentType = transactionEvent.GetType().ToString();
+			message.UserProperties.Add("CryptoCode", transactionEvent.CryptoCode);
 			await Client.SendAsync(message);
 		}
 
@@ -47,6 +48,7 @@ namespace NBXplorer.MessageBrokers
 			var message = new Message(bytes);
 			message.MessageId = blockEvent.Hash.ToString();
 			message.ContentType = blockEvent.GetType().ToString();
+			message.UserProperties.Add("CryptoCode", blockEvent.CryptoCode);			
 			await Client.SendAsync(message);
 		}
 


### PR DESCRIPTION
Added a user property for crypto code to published transaction and block messages.
User can get this data from subscribed messages and than can create NBXplorerNetwork to deserialize received messsages.

```
string cryptoCode = message.UserProperties.TryGet("CryptoCode").ToString();

NBXplorerNetwork network = new NBXplorerNetworkProvider(NetworkType.Regtest).GetFromCryptoCode(cryptoCode); 
JsonSerializerSettings settings = new JsonSerializerSettings();
new Serializer(network).ConfigureSerializer(settings);

NewTransactionEvent newEventTx = JsonConvert.DeserializeObject<NewTransactionEvent>(Encoding.UTF8.GetString(message.Body), settings);
```