### PR TITLE
Fix NBXplorerNetworkProvider testnet init

### DIFF
--- a/NBXplorer.Client/NBXplorerNetworkProvider.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.cs
@@ -1,7 +1,5 @@
 ﻿using NBitcoin;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace NBXplorer
 {
@@ -54,6 +52,8 @@ namespace NBXplorer
 		Dictionary<string, NBXplorerNetwork> _Networks = new Dictionary<string, NBXplorerNetwork>();
 		private void Add(NBXplorerNetwork network)
 		{
+			if (network.NBitcoinNetwork == null)
+				return;
 			_Networks.Add(network.CryptoCode, network);
 		}
 	}

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -35,6 +35,15 @@ namespace NBXplorer.Tests
 		}
 
 		[Fact]
+		public void CanCreateNetworkProvider()
+		{
+			foreach (var networkType in Enum.GetValues(typeof(NetworkType)))
+			{
+				_ = new NBXplorerNetworkProvider((NetworkType) networkType);
+			}
+		}
+
+		[Fact]
 		public void CanFixedSizeCache()
 		{
 			FixedSizeCache<uint256, uint256> cache = new FixedSizeCache<uint256, uint256>(2, k => k);


### PR DESCRIPTION
Instantiating `NBXplorerNetworkProvider` with testnet would crash as liquid has no testnet Network set.