### PR TITLE
refactor deriv strategy options and allow elements unblinded flag

### DIFF
--- a/NBXplorer.Client/DerivationStrategy/DerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/DerivationStrategy.cs
@@ -55,7 +55,8 @@ namespace NBXplorer.DerivationStrategy
 		/// </summary>
 		public bool KeepOrder
 		{
-			get; set;
+			get => AdditionalOptions.TryGetValue("keeporder", out var keeporder) && keeporder;
+			set => AdditionalOptions.AddOrReplace("keeporder", value);
 		}
 	}
 	public class DerivationStrategyFactory
@@ -148,7 +149,7 @@ namespace NBXplorer.DerivationStrategy
 
 			if(options.ScriptPubKeyType == ScriptPubKeyType.SegwitP2SH)
 			{
-				strategy = new P2SHDerivationStrategy(strategy, true, options);
+				strategy = new P2SHDerivationStrategy(strategy, false, options);
 			}
 			return strategy;
 		}

--- a/NBXplorer.Client/DerivationStrategy/DerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/DerivationStrategy.cs
@@ -11,7 +11,43 @@ namespace NBXplorer.DerivationStrategy
 {
 	public class DerivationStrategyOptions
 	{
-		public ScriptPubKeyType ScriptPubKeyType { get; set; }
+
+		public ScriptPubKeyType ScriptPubKeyType
+		{
+			get
+			{
+				if (AdditionalOptions.TryGetValue("legacy", out var legacy) && legacy)
+				{
+					return ScriptPubKeyType.Legacy;
+				}
+				if (AdditionalOptions.TryGetValue("p2sh", out var p2sh) && p2sh)
+				{
+					return ScriptPubKeyType.SegwitP2SH;
+				}
+				return ScriptPubKeyType.Segwit;
+			}
+			set
+			{
+				switch (value)
+				{
+					case ScriptPubKeyType.Legacy:
+						AdditionalOptions.AddOrReplace("legacy", true);
+						AdditionalOptions.AddOrReplace("p2sh", false);
+						break;
+					case ScriptPubKeyType.Segwit:
+						AdditionalOptions.AddOrReplace("legacy", false);
+						AdditionalOptions.AddOrReplace("p2sh", false);
+						break;
+					case ScriptPubKeyType.SegwitP2SH:
+						AdditionalOptions.AddOrReplace("legacy", false);
+						AdditionalOptions.AddOrReplace("p2sh", true);
+						break;
+					default:
+						throw new ArgumentOutOfRangeException(nameof(value), value, null);
+				}
+			}
+		}
+
 		public Dictionary<string,bool> AdditionalOptions { get; set; } = new Dictionary<string, bool>();
 
 		/// <summary>

--- a/NBXplorer.Client/DerivationStrategy/DerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/DerivationStrategy.cs
@@ -11,23 +11,30 @@ namespace NBXplorer.DerivationStrategy
 {
 	public class DerivationStrategyOptions
 	{
-
+		private ScriptPubKeyType? _scriptPubKeyType = null;
 		public ScriptPubKeyType ScriptPubKeyType
 		{
 			get
 			{
-				if (AdditionalOptions.TryGetValue("legacy", out var legacy) && legacy)
+
+				if (_scriptPubKeyType == null)
 				{
-					return ScriptPubKeyType.Legacy;
+					if (AdditionalOptions.TryGetValue("legacy", out var legacy) && legacy)
+					{
+						return ScriptPubKeyType.Legacy;
+					}
+					if (AdditionalOptions.TryGetValue("p2sh", out var p2sh) && p2sh)
+					{
+						return ScriptPubKeyType.SegwitP2SH;
+					}
+					_scriptPubKeyType =  ScriptPubKeyType.Segwit;
 				}
-				if (AdditionalOptions.TryGetValue("p2sh", out var p2sh) && p2sh)
-				{
-					return ScriptPubKeyType.SegwitP2SH;
-				}
-				return ScriptPubKeyType.Segwit;
+
+				return _scriptPubKeyType.Value;
 			}
 			set
 			{
+				_scriptPubKeyType = value;
 				switch (value)
 				{
 					case ScriptPubKeyType.Legacy:

--- a/NBXplorer.Client/DerivationStrategy/DirectDerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/DirectDerivationStrategy.cs
@@ -18,27 +18,20 @@ namespace NBXplorer.DerivationStrategy
 			}
 		}
 
-		public bool Segwit
-		{
-			get;
-			set;
-		}
+		public bool Segwit => DerivationStrategyOptions.ScriptPubKeyType != ScriptPubKeyType.Segwit;
 
 		protected override string StringValue
 		{
 			get
 			{
 				StringBuilder builder = new StringBuilder();
-				builder.Append(_Root.ToString());
-				if(!Segwit)
-				{
-					builder.Append("-[legacy]");
-				}
+				builder.Append(_Root);
+				builder.Append(GetSuffixOptionsString());
 				return builder.ToString();
 			}
 		}
 
-		public DirectDerivationStrategy(BitcoinExtPubKey root)
+		public DirectDerivationStrategy(BitcoinExtPubKey root, DerivationStrategyOptions options) : base(options)
 		{
 			if(root == null)
 				throw new ArgumentNullException(nameof(root));
@@ -52,7 +45,8 @@ namespace NBXplorer.DerivationStrategy
 
 		public override DerivationStrategyBase GetChild(KeyPath keyPath)
 		{
-			return new DirectDerivationStrategy(_Root.ExtPubKey.Derive(keyPath).GetWif(_Root.Network)) { Segwit = Segwit };
+			return new DirectDerivationStrategy(_Root.ExtPubKey.Derive(keyPath).GetWif(_Root.Network),
+				DerivationStrategyOptions);
 		}
 
 		public override IEnumerable<ExtPubKey> GetExtPubKeys()

--- a/NBXplorer.Client/DerivationStrategy/IStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/IStrategy.cs
@@ -2,6 +2,7 @@
 using NBitcoin.Crypto;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace NBXplorer.DerivationStrategy
@@ -15,9 +16,11 @@ namespace NBXplorer.DerivationStrategy
 	}
 	public abstract class DerivationStrategyBase : IHDScriptPubKey
 	{
-		internal DerivationStrategyBase()
-		{
+		public DerivationStrategyOptions DerivationStrategyOptions { get; }
 
+		internal DerivationStrategyBase(DerivationStrategyOptions derivationStrategyOptions)
+		{
+			DerivationStrategyOptions = derivationStrategyOptions;
 		}
 
 		public DerivationLine GetLineFor(KeyPathTemplate keyPathTemplate)
@@ -41,6 +44,12 @@ namespace NBXplorer.DerivationStrategy
 		protected abstract string StringValue
 		{
 			get;
+		}
+
+		protected string GetSuffixOptionsString()
+		{
+			return string.Join("",
+				DerivationStrategyOptions.AdditionalOptions.Where(pair => pair.Value).Select(pair => $"-[{pair.Key}]"));
 		}
 
 		public override bool Equals(object obj)

--- a/NBXplorer.Client/DerivationStrategy/P2SHDerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/P2SHDerivationStrategy.cs
@@ -11,7 +11,7 @@ namespace NBXplorer.DerivationStrategy
 	public class P2SHDerivationStrategy : DerivationStrategyBase
 	{
 		bool addSuffix;
-		internal P2SHDerivationStrategy(DerivationStrategyBase inner, bool addSuffix)
+		internal P2SHDerivationStrategy(DerivationStrategyBase inner, bool addSuffix, DerivationStrategyOptions options) : base(options)
 		{
 			if(inner == null)
 				throw new ArgumentNullException(nameof(inner));
@@ -29,7 +29,7 @@ namespace NBXplorer.DerivationStrategy
 			get
 			{
 				if(addSuffix)
-					return Inner.ToString() + "-[p2sh]";
+					return $"{Inner}{GetSuffixOptionsString()}";
 				return Inner.ToString();
 			}
 		}
@@ -51,7 +51,7 @@ namespace NBXplorer.DerivationStrategy
 
 		public override DerivationStrategyBase GetChild(KeyPath keyPath)
 		{
-			return new P2SHDerivationStrategy(Inner.GetChild(keyPath), addSuffix);
+			return new P2SHDerivationStrategy(Inner.GetChild(keyPath), addSuffix, DerivationStrategyOptions);
 		}
 	}
 }

--- a/NBXplorer.Client/DerivationStrategy/P2SHDerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/P2SHDerivationStrategy.cs
@@ -24,15 +24,7 @@ namespace NBXplorer.DerivationStrategy
 			get; set;
 		}
 
-		protected override string StringValue
-		{
-			get
-			{
-				if(addSuffix)
-					return $"{Inner}{GetSuffixOptionsString()}";
-				return Inner.ToString();
-			}
-		}
+		protected override string StringValue => addSuffix ? $"{Inner}{GetSuffixOptionsString()}" : Inner.ToString();
 
 		public override Derivation GetDerivation()
 		{

--- a/NBXplorer.Client/DerivationStrategy/P2WSHDerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/P2WSHDerivationStrategy.cs
@@ -10,7 +10,7 @@ namespace NBXplorer.DerivationStrategy
 {
 	public class P2WSHDerivationStrategy : DerivationStrategyBase
 	{
-		internal P2WSHDerivationStrategy(DerivationStrategyBase inner)
+		internal P2WSHDerivationStrategy(DerivationStrategyBase inner, DerivationStrategyOptions options) : base(options)
 		{
 			if(inner == null)
 				throw new ArgumentNullException(nameof(inner));
@@ -41,7 +41,7 @@ namespace NBXplorer.DerivationStrategy
 
 		public override DerivationStrategyBase GetChild(KeyPath keyPath)
 		{
-			return new P2WSHDerivationStrategy(Inner.GetChild(keyPath));
+			return new P2WSHDerivationStrategy(Inner.GetChild(keyPath), DerivationStrategyOptions);
 		}
 	}
 }

--- a/NBXplorer.Client/NBXplorerNetworkProvider.Liquid.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Liquid.cs
@@ -29,10 +29,9 @@ namespace NBXplorer
 
 			public static Key GenerateBlindingKey(DerivationStrategyBase derivationStrategy, KeyPath keyPath)
 			{
-				if (derivationStrategy.DerivationStrategyOptions.AdditionalOptions.TryGetValue("unblinded",
-					    out var unblinded) && unblinded)
+				if (derivationStrategy.DerivationStrategyOptions.Unblinded())
 				{
-					return null;
+					throw new InvalidOperationException("This derivation scheme is set to only track unblinded addresses");
 				}
 				var blindingKey = new Key(derivationStrategy.GetChild(keyPath).GetChild(new KeyPath("0")).GetDerivation()
 					.ScriptPubKey.WitHash.ToBytes());
@@ -51,6 +50,14 @@ namespace NBXplorer
 		public NBXplorerNetwork GetLBTC()
 		{
 			return GetFromCryptoCode(NBitcoin.Altcoins.Liquid.Instance.CryptoCode);
+		}
+	}
+	
+	public static class LiquidDerivationStrategyOptionsExtensions
+	{
+		public static bool Unblinded(this DerivationStrategyOptions derivationStrategyOptions)
+		{
+			return derivationStrategyOptions.AdditionalOptions.TryGetValue("unblinded", out var unblinded) && unblinded;
 		}
 	}
 }

--- a/NBXplorer.Client/NBXplorerNetworkProvider.Liquid.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Liquid.cs
@@ -29,6 +29,11 @@ namespace NBXplorer
 
 			public static Key GenerateBlindingKey(DerivationStrategyBase derivationStrategy, KeyPath keyPath)
 			{
+				if (derivationStrategy.DerivationStrategyOptions.AdditionalOptions.TryGetValue("unblinded",
+					    out var unblinded) && unblinded)
+				{
+					return null;
+				}
 				var blindingKey = new Key(derivationStrategy.GetChild(keyPath).GetChild(new KeyPath("0")).GetDerivation()
 					.ScriptPubKey.WitHash.ToBytes());
 				return blindingKey;

--- a/NBXplorer.Tests/ServerTester.Environment.cs
+++ b/NBXplorer.Tests/ServerTester.Environment.cs
@@ -75,13 +75,13 @@ namespace NBXplorer.Tests
 			//Network = NBitcoin.Altcoins.Colossus.Instance.Regtest;
 			//RPCSupportSegwit = false;
 
-			CryptoCode = "LBTC";
-			nodeDownloadData = NodeDownloadData.Elements.v0_18_1_1;
-			NBXplorerNetwork = new NBXplorerNetwork(NBitcoin.Altcoins.Liquid.Instance, NetworkType.Regtest);
+			// CryptoCode = "LBTC";
+			// nodeDownloadData = NodeDownloadData.Elements.v0_18_1_1;
+			// NBXplorerNetwork = new NBXplorerNetwork(NBitcoin.Altcoins.Liquid.Instance, NetworkType.Regtest);
 			
-//			CryptoCode = "BTC";
-//			nodeDownloadData = NodeDownloadData.Bitcoin.v0_18_0;
-//			NBXplorerNetwork = new NBXplorerNetwork(Network.RegTest.NetworkSet, NetworkType.Regtest);
+			CryptoCode = "BTC";
+			nodeDownloadData = NodeDownloadData.Bitcoin.v0_18_0;
+			NBXplorerNetwork = new NBXplorerNetwork(Network.RegTest.NetworkSet, NetworkType.Regtest);
 		}
 	}
 }

--- a/NBXplorer.Tests/ServerTester.Environment.cs
+++ b/NBXplorer.Tests/ServerTester.Environment.cs
@@ -75,13 +75,13 @@ namespace NBXplorer.Tests
 			//Network = NBitcoin.Altcoins.Colossus.Instance.Regtest;
 			//RPCSupportSegwit = false;
 
-			//CryptoCode = "LBTC";
-			//nodeDownloadData = NodeDownloadData.Elements.v0_18_1_1;
-			//NBXplorerNetwork = new NBXplorerNetwork(NBitcoin.Altcoins.Liquid.Instance, NetworkType.Regtest);
-			//
-			CryptoCode = "BTC";
-			nodeDownloadData = NodeDownloadData.Bitcoin.v0_18_0;
-			NBXplorerNetwork = new NBXplorerNetwork(Network.RegTest.NetworkSet, NetworkType.Regtest);
+			CryptoCode = "LBTC";
+			nodeDownloadData = NodeDownloadData.Elements.v0_18_1_1;
+			NBXplorerNetwork = new NBXplorerNetwork(NBitcoin.Altcoins.Liquid.Instance, NetworkType.Regtest);
+			
+//			CryptoCode = "BTC";
+//			nodeDownloadData = NodeDownloadData.Bitcoin.v0_18_0;
+//			NBXplorerNetwork = new NBXplorerNetwork(Network.RegTest.NetworkSet, NetworkType.Regtest);
 		}
 	}
 }

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -3180,6 +3180,47 @@ namespace NBXplorer.Tests
 		}
 
 		[Fact]
+		public async Task CanParseAndGenerateDerivStringCorrectly()
+		{
+			using (var tester = ServerTester.Create())
+			{
+
+				var xpub = new Mnemonic(Wordlist.English).DeriveExtKey().Neuter().GetWif(tester.Network).ToString();
+				var segwitDeriv = $"{xpub}";
+				var segwit = tester.Client.Network.DerivationStrategyFactory.Parse(segwitDeriv);
+				Assert.Equal(ScriptPubKeyType.Segwit, segwit.DerivationStrategyOptions.ScriptPubKeyType);
+				Assert.Equal(segwitDeriv, segwit.ToString());
+
+
+				var p2shDeriv = $"{xpub}-[p2sh]";
+				var p2sh = tester.Client.Network.DerivationStrategyFactory.Parse(p2shDeriv);
+				Assert.Equal(ScriptPubKeyType.SegwitP2SH, p2sh.DerivationStrategyOptions.ScriptPubKeyType);
+				Assert.Equal(p2shDeriv, p2sh.ToString());
+
+
+				var legacyDeriv = $"{xpub}-[legacy]";
+				var legacy = tester.Client.Network.DerivationStrategyFactory.Parse(legacyDeriv);
+				Assert.Equal(ScriptPubKeyType.Legacy, legacy.DerivationStrategyOptions.ScriptPubKeyType);
+				Assert.Equal(legacyDeriv, legacy.ToString());
+
+
+				var xpub2 = new Mnemonic(Wordlist.English).DeriveExtKey().Neuter().GetWif(tester.Network).ToString();
+				var multisig = $"2-of-{xpub}-{xpub2}";
+				var multisigDeriv = tester.Client.Network.DerivationStrategyFactory.Parse(multisig);
+				Assert.Equal(ScriptPubKeyType.Segwit, multisigDeriv.DerivationStrategyOptions.ScriptPubKeyType);
+				Assert.Equal(false, multisigDeriv.DerivationStrategyOptions.KeepOrder);
+				Assert.Equal(multisig, multisigDeriv.ToString());
+				
+				var multisigKeeporder = $"{multisig}-[keeporder]";
+				var multisigDerivKeeporder = tester.Client.Network.DerivationStrategyFactory.Parse(multisigKeeporder);
+				Assert.Equal(ScriptPubKeyType.Segwit, multisigDerivKeeporder.DerivationStrategyOptions.ScriptPubKeyType);
+				Assert.Equal(true, multisigDerivKeeporder.DerivationStrategyOptions.KeepOrder);
+				Assert.Equal(multisigKeeporder, multisigDerivKeeporder.ToString());
+			}
+		}
+
+
+		[Fact]
 		public async Task CanGenerateWallet()
 		{
 			using (var tester = ServerTester.Create())

--- a/NBXplorer/Altcoins/Liquid/LiquidRepository.cs
+++ b/NBXplorer/Altcoins/Liquid/LiquidRepository.cs
@@ -4,12 +4,10 @@ using System.Threading.Tasks;
 using DBriize;
 using NBitcoin;
 using NBitcoin.Altcoins.Elements;
-using NBXplorer.Altcoins.Liquid;
 using NBitcoin.RPC;
 using NBXplorer.Models;
-using System;
 
-namespace NBXplorer
+namespace NBXplorer.Altcoins.Liquid
 {
 	public class LiquidRepository : Repository
 	{
@@ -192,7 +190,7 @@ namespace NBXplorer
 					.Select(kv => (KeyPath: kv.KeyPath,
 								   Address: kv.Address as BitcoinBlindedAddress,
 								   BlindingKey: NBXplorerNetworkProvider.LiquidNBXplorerNetwork.GenerateBlindingKey(ts.DerivationStrategy, kv.KeyPath)))
-					.Where(o => o.Address != null)
+					.Where(o => o.Address != null && o.BlindingKey != null)
 					.Select(o => new UnblindTransactionBlindingAddressKey()
 					{
 						Address = o.Address,

--- a/NBXplorer/Altcoins/Liquid/LiquidRepository.cs
+++ b/NBXplorer/Altcoins/Liquid/LiquidRepository.cs
@@ -183,6 +183,7 @@ namespace NBXplorer.Altcoins.Liquid
 		{
 			await base.AfterMatch(tx, keyInfos);
 			if (tx.TrackedSource is DerivationSchemeTrackedSource ts &&
+			    !ts.DerivationStrategy.DerivationStrategyOptions.Unblinded() && 
 				tx.Transaction is ElementsTransaction elementsTransaction &&
 				tx is ElementsTrackedTransaction elementsTracked)
 			{
@@ -190,7 +191,7 @@ namespace NBXplorer.Altcoins.Liquid
 					.Select(kv => (KeyPath: kv.KeyPath,
 								   Address: kv.Address as BitcoinBlindedAddress,
 								   BlindingKey: NBXplorerNetworkProvider.LiquidNBXplorerNetwork.GenerateBlindingKey(ts.DerivationStrategy, kv.KeyPath)))
-					.Where(o => o.Address != null && o.BlindingKey != null)
+					.Where(o => o.Address != null)
 					.Select(o => new UnblindTransactionBlindingAddressKey()
 					{
 						Address = o.Address,

--- a/NBXplorer/Repository.cs
+++ b/NBXplorer/Repository.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using NBitcoin.Altcoins;
 using NBitcoin.RPC;
+using NBXplorer.Altcoins.Liquid;
 using NBXplorer.Logging;
 using NBXplorer.Configuration;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
This lets all the derivation implementations have access to all options + creates a generic way to read additional options along with generating the string suffixes.

Then I leveraged it and added support for `-[unblinded]` for liquid without needing to creating derived classes fro derivations. 