### PR TITLE
Custom auth header

### DIFF
--- a/NBXplorer.Client/ExplorerClient.cs
+++ b/NBXplorer.Client/ExplorerClient.cs
@@ -27,7 +27,6 @@ namespace NBXplorer
 			void SetWebSocketAuth(ClientWebSocket socket);
 		}
 
-
 		class CookieAuthentication : IAuth
 		{
 			string _CookieFilePath;
@@ -46,10 +45,7 @@ namespace NBXplorer
 					_CachedAuth = new AuthenticationHeaderValue("Basic", Encoders.Base64.EncodeData(Encoders.ASCII.DecodeData(cookieData)));
 					return true;
 				}
-				catch
-				{
-					return false;
-				}
+				catch { return false; }
 			}
 
 			public void SetAuthorization(HttpRequestMessage message)
@@ -63,7 +59,6 @@ namespace NBXplorer
 					socket.Options.SetRequestHeader("Authorization", $"{_CachedAuth.Scheme} {_CachedAuth.Parameter}");
 			}
 		}
-
 		class NullAuthentication : IAuth
 		{
 			public bool RefreshCache()
@@ -79,7 +74,7 @@ namespace NBXplorer
 			{
 			}
 		}
-
+		
 		class CustomAuthentication : IAuth
 		{
 			AuthenticationHeaderValue _CachedAuth;
@@ -124,7 +119,6 @@ namespace NBXplorer
 			{
 				_Auth = new CustomAuthentication(customAuthHeader);
 			}
-			
 		}
 
 		internal IAuth _Auth = new NullAuthentication();
@@ -144,19 +138,19 @@ namespace NBXplorer
 		}
 
 		private readonly string _CryptoCode = "BTC";
-
 		public string CryptoCode
 		{
-			get { return _CryptoCode; }
+			get
+			{
+				return _CryptoCode;
+			}
 		}
 
 		DerivationStrategy.DerivationStrategyFactory _Factory;
-
 		public UTXOChanges GetUTXOs(DerivationStrategyBase extKey, CancellationToken cancellation = default)
 		{
 			return GetUTXOsAsync(extKey, cancellation).GetAwaiter().GetResult();
 		}
-
 		public Task<UTXOChanges> GetUTXOsAsync(DerivationStrategyBase extKey, CancellationToken cancellation = default)
 		{
 			if (extKey == null)
@@ -166,8 +160,7 @@ namespace NBXplorer
 
 		public async Task<TransactionResult> GetTransactionAsync(uint256 txId, CancellationToken cancellation = default)
 		{
-			return await SendAsync<TransactionResult>(HttpMethod.Get, null, "v1/cryptos/{0}/transactions/" + txId, new[] {CryptoCode}, cancellation)
-				.ConfigureAwait(false);
+			return await SendAsync<TransactionResult>(HttpMethod.Get, null, "v1/cryptos/{0}/transactions/" + txId, new[] { CryptoCode }, cancellation).ConfigureAwait(false);
 		}
 
 		public TransactionResult GetTransaction(uint256 txId, CancellationToken cancellation = default)
@@ -175,13 +168,11 @@ namespace NBXplorer
 			return GetTransactionAsync(txId, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task<PruneResponse> PruneAsync(DerivationStrategyBase extKey, PruneRequest pruneRequest,
-			CancellationToken cancellation = default)
+		public async Task<PruneResponse> PruneAsync(DerivationStrategyBase extKey, PruneRequest pruneRequest, CancellationToken cancellation = default)
 		{
 			if (extKey == null)
 				throw new ArgumentNullException(nameof(extKey));
-			return await SendAsync<PruneResponse>(HttpMethod.Post, pruneRequest, "v1/cryptos/{0}/derivations/{1}/prune",
-				new object[] {Network.CryptoCode, extKey}, cancellation).ConfigureAwait(false);
+			return await SendAsync<PruneResponse>(HttpMethod.Post, pruneRequest, "v1/cryptos/{0}/derivations/{1}/prune", new object[] { Network.CryptoCode, extKey }, cancellation).ConfigureAwait(false);
 		}
 
 		public PruneResponse Prune(DerivationStrategyBase extKey, PruneRequest pruneRequest, CancellationToken cancellation = default)
@@ -189,8 +180,7 @@ namespace NBXplorer
 			return PruneAsync(extKey, pruneRequest, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task ScanUTXOSetAsync(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null,
-			CancellationToken cancellation = default)
+		public async Task ScanUTXOSetAsync(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null, CancellationToken cancellation = default)
 		{
 			if (extKey == null)
 				throw new ArgumentNullException(nameof(extKey));
@@ -204,20 +194,16 @@ namespace NBXplorer
 			var argsString = string.Join("&", args.ToArray());
 			if (argsString != string.Empty)
 				argsString = $"?{argsString}";
-			await SendAsync<bool>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan{2}",
-				new object[] {Network.CryptoCode, extKey, argsString}, cancellation).ConfigureAwait(false);
+			await SendAsync<bool>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan{2}", new object[] { Network.CryptoCode, extKey, argsString }, cancellation).ConfigureAwait(false);
 		}
-
-		public void ScanUTXOSet(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null,
-			CancellationToken cancellation = default)
+		public void ScanUTXOSet(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null, CancellationToken cancellation = default)
 		{
 			ScanUTXOSetAsync(extKey, batchSize, gapLimit, fromIndex, cancellation).GetAwaiter().GetResult();
 		}
 
 		public async Task<ScanUTXOInformation> GetScanUTXOSetInformationAsync(DerivationStrategyBase extKey, CancellationToken cancellation = default)
 		{
-			return await SendAsync<ScanUTXOInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan",
-				new object[] {Network.CryptoCode, extKey}, cancellation).ConfigureAwait(false);
+			return await SendAsync<ScanUTXOInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan", new object[] { Network.CryptoCode, extKey }, cancellation).ConfigureAwait(false);
 		}
 
 		public ScanUTXOInformation GetScanUTXOSetInformation(DerivationStrategyBase extKey, CancellationToken cancellation = default)
@@ -246,20 +232,17 @@ namespace NBXplorer
 		{
 			return GetUTXOsAsync(trackedSource, cancellation).GetAwaiter().GetResult();
 		}
-
 		public async Task<UTXOChanges> GetUTXOsAsync(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			if (trackedSource == null)
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos",
-					new object[] {CryptoCode, dsts.DerivationStrategy.ToString()}, cancellation).ConfigureAwait(false);
+				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos", new object[] { CryptoCode, dsts.DerivationStrategy.ToString() }, cancellation).ConfigureAwait(false);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/addresses/{1}/utxos",
-					new object[] {CryptoCode, asts.Address}, cancellation).ConfigureAwait(false);
+				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/addresses/{1}/utxos", new object[] { CryptoCode, asts.Address }, cancellation).ConfigureAwait(false);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -269,7 +252,6 @@ namespace NBXplorer
 		{
 			WaitServerStartedAsync(cancellation).GetAwaiter().GetResult();
 		}
-
 		public async Task WaitServerStartedAsync(CancellationToken cancellation = default)
 		{
 			while (true)
@@ -281,14 +263,8 @@ namespace NBXplorer
 						break;
 					await Task.Delay(10);
 				}
-				catch (OperationCanceledException)
-				{
-					throw;
-				}
-				catch
-				{
-				}
-
+				catch (OperationCanceledException) { throw; }
+				catch { }
 				cancellation.ThrowIfCancellationRequested();
 			}
 		}
@@ -298,7 +274,6 @@ namespace NBXplorer
 		{
 			TrackAsync(strategy, cancellation).GetAwaiter().GetResult();
 		}
-
 		public Task TrackAsync(DerivationStrategyBase strategy, CancellationToken cancellation = default)
 		{
 			return TrackAsync(TrackedSource.Create(strategy), cancellation);
@@ -308,34 +283,28 @@ namespace NBXplorer
 		{
 			TrackAsync(strategy, trackDerivationRequest, cancellation).GetAwaiter().GetResult();
 		}
-
-		public async Task TrackAsync(DerivationStrategyBase strategy, TrackWalletRequest trackDerivationRequest,
-			CancellationToken cancellation = default)
+		public async Task TrackAsync(DerivationStrategyBase strategy, TrackWalletRequest trackDerivationRequest, CancellationToken cancellation = default)
 		{
 			if (strategy == null)
 				throw new ArgumentNullException(nameof(strategy));
-			await SendAsync<string>(HttpMethod.Post, trackDerivationRequest, "v1/cryptos/{0}/derivations/{1}",
-				new[] {CryptoCode, strategy.ToString()}, cancellation).ConfigureAwait(false);
+			await SendAsync<string>(HttpMethod.Post, trackDerivationRequest, "v1/cryptos/{0}/derivations/{1}", new[] { CryptoCode, strategy.ToString() }, cancellation).ConfigureAwait(false);
 		}
 
 		public void Track(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			TrackAsync(trackedSource, cancellation).GetAwaiter().GetResult();
 		}
-
 		public Task TrackAsync(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			if (trackedSource == null)
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}",
-					new[] {CryptoCode, dsts.DerivationStrategy.ToString()}, cancellation);
+				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}", new[] { CryptoCode, dsts.DerivationStrategy.ToString() }, cancellation);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/addresses/{1}", new[] {CryptoCode, asts.Address.ToString()},
-					cancellation);
+				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/addresses/{1}", new[] { CryptoCode, asts.Address.ToString() }, cancellation);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -355,17 +324,14 @@ namespace NBXplorer
 		{
 			return GetBalanceAsync(userDerivationScheme).GetAwaiter().GetResult();
 		}
-
 		public Task<GetBalanceResponse> GetBalanceAsync(DerivationStrategyBase userDerivationScheme, CancellationToken cancellation = default)
 		{
-			return SendAsync<GetBalanceResponse>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/balance",
-				new[] {CryptoCode, userDerivationScheme.ToString()}, cancellation);
+			return SendAsync<GetBalanceResponse>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/balance", new[] { CryptoCode, userDerivationScheme.ToString() }, cancellation);
 		}
 
 		public Task CancelReservationAsync(DerivationStrategyBase strategy, KeyPath[] keyPaths, CancellationToken cancellation = default)
 		{
-			return SendAsync<string>(HttpMethod.Post, keyPaths, "v1/cryptos/{0}/derivations/{1}/addresses/cancelreservation",
-				new[] {CryptoCode, strategy.ToString()}, cancellation);
+			return SendAsync<string>(HttpMethod.Post, keyPaths, "v1/cryptos/{0}/derivations/{1}/addresses/cancelreservation", new[] { CryptoCode, strategy.ToString() }, cancellation);
 		}
 
 		public StatusResult GetStatus(CancellationToken cancellation = default)
@@ -377,12 +343,10 @@ namespace NBXplorer
 		{
 			return SendAsync<StatusResult>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/status", null, cancellation);
 		}
-
 		public GetTransactionsResponse GetTransactions(DerivationStrategyBase strategy, CancellationToken cancellation = default)
 		{
 			return GetTransactionsAsync(strategy, cancellation).GetAwaiter().GetResult();
 		}
-
 		public GetTransactionsResponse GetTransactions(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			return GetTransactionsAsync(trackedSource, cancellation).GetAwaiter().GetResult();
@@ -392,20 +356,17 @@ namespace NBXplorer
 		{
 			return GetTransactionsAsync(TrackedSource.Create(strategy), cancellation);
 		}
-
 		public Task<GetTransactionsResponse> GetTransactionsAsync(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			if (trackedSource == null)
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null,
-					$"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions", null, cancellation);
+				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions", null, cancellation);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions",
-					null, cancellation);
+				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions", null, cancellation);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -416,15 +377,11 @@ namespace NBXplorer
 		{
 			return this.GetTransactionAsync(trackedSource, txId, cancellation).GetAwaiter().GetResult();
 		}
-
-		public TransactionInformation GetTransaction(DerivationStrategyBase derivationStrategyBase, uint256 txId,
-			CancellationToken cancellation = default)
+		public TransactionInformation GetTransaction(DerivationStrategyBase derivationStrategyBase, uint256 txId, CancellationToken cancellation = default)
 		{
 			return this.GetTransactionAsync(derivationStrategyBase, txId, cancellation).GetAwaiter().GetResult();
 		}
-
-		public Task<TransactionInformation> GetTransactionAsync(DerivationStrategyBase derivationStrategyBase, uint256 txId,
-			CancellationToken cancellation = default)
+		public Task<TransactionInformation> GetTransactionAsync(DerivationStrategyBase derivationStrategyBase, uint256 txId, CancellationToken cancellation = default)
 		{
 			if (derivationStrategyBase == null)
 				throw new ArgumentNullException(nameof(derivationStrategyBase));
@@ -439,13 +396,11 @@ namespace NBXplorer
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return SendAsync<TransactionInformation>(HttpMethod.Get, null,
-					$"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions/{txId}", null, cancellation);
+				return SendAsync<TransactionInformation>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions/{txId}", null, cancellation);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return SendAsync<TransactionInformation>(HttpMethod.Get, null,
-					$"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions/{txId}", null, cancellation);
+				return SendAsync<TransactionInformation>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions/{txId}", null, cancellation);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -463,20 +418,16 @@ namespace NBXplorer
 			RescanAsync(rescanRequest, cancellation).GetAwaiter().GetResult();
 		}
 
-		public KeyPathInformation GetUnused(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0, bool reserve = false,
-			CancellationToken cancellation = default)
+		public KeyPathInformation GetUnused(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0, bool reserve = false, CancellationToken cancellation = default)
 		{
 			return GetUnusedAsync(strategy, feature, skip, reserve, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task<KeyPathInformation> GetUnusedAsync(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0,
-			bool reserve = false, CancellationToken cancellation = default)
+		public async Task<KeyPathInformation> GetUnusedAsync(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0, bool reserve = false, CancellationToken cancellation = default)
 		{
 			try
 			{
-				return await GetAsync<KeyPathInformation>(
-					$"v1/cryptos/{CryptoCode}/derivations/{strategy}/addresses/unused?feature={feature}&skip={skip}&reserve={reserve}", null,
-					cancellation).ConfigureAwait(false);
+				return await GetAsync<KeyPathInformation>($"v1/cryptos/{CryptoCode}/derivations/{strategy}/addresses/unused?feature={feature}&skip={skip}&reserve={reserve}", null, cancellation).ConfigureAwait(false);
 			}
 			catch (NBXplorerException ex) when (ex.Error?.HttpCode == 404)
 			{
@@ -489,18 +440,15 @@ namespace NBXplorer
 			return GetKeyInformationAsync(strategy, script, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task<KeyPathInformation> GetKeyInformationAsync(DerivationStrategyBase strategy, Script script,
-			CancellationToken cancellation = default)
+		public async Task<KeyPathInformation> GetKeyInformationAsync(DerivationStrategyBase strategy, Script script, CancellationToken cancellation = default)
 		{
-			return await SendAsync<KeyPathInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/scripts/" + script.ToHex(),
-				new object[] {CryptoCode, strategy}, cancellation).ConfigureAwait(false);
+			return await SendAsync<KeyPathInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/scripts/" + script.ToHex(), new object[] { CryptoCode, strategy }, cancellation).ConfigureAwait(false);
 		}
 
 		[Obsolete("Use GetKeyInformationAsync(DerivationStrategyBase strategy, Script script) instead")]
 		public async Task<KeyPathInformation[]> GetKeyInformationsAsync(Script script, CancellationToken cancellation = default)
 		{
-			return await SendAsync<KeyPathInformation[]>(HttpMethod.Get, null, "v1/cryptos/{0}/scripts/" + script.ToHex(), new[] {CryptoCode},
-				cancellation).ConfigureAwait(false);
+			return await SendAsync<KeyPathInformation[]>(HttpMethod.Get, null, "v1/cryptos/{0}/scripts/" + script.ToHex(), new[] { CryptoCode }, cancellation).ConfigureAwait(false);
 		}
 
 		[Obsolete("Use GetKeyInformation(DerivationStrategyBase strategy, Script script) instead")]
@@ -518,60 +466,48 @@ namespace NBXplorer
 		{
 			return GetFeeRateAsync(blockCount, fallbackFeeRate, cancellation).GetAwaiter().GetResult();
 		}
-
 		public async Task<GetFeeRateResult> GetFeeRateAsync(int blockCount, FeeRate fallbackFeeRate, CancellationToken cancellation = default)
 		{
 			try
 			{
-				return await GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] {CryptoCode, blockCount}, cancellation)
-					.ConfigureAwait(false);
+				return await GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] { CryptoCode, blockCount }, cancellation).ConfigureAwait(false);
 			}
 			catch (NBXplorerException ex) when (fallbackFeeRate != null && ex.Error.Code == "fee-estimation-unavailable")
 			{
-				return new GetFeeRateResult() {BlockCount = blockCount, FeeRate = fallbackFeeRate};
+				return new GetFeeRateResult() { BlockCount = blockCount, FeeRate = fallbackFeeRate };
 			}
 		}
-
 		public Task<GetFeeRateResult> GetFeeRateAsync(int blockCount, CancellationToken cancellation = default)
 		{
-			return GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] {CryptoCode, blockCount}, cancellation);
+			return GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] { CryptoCode, blockCount }, cancellation);
 		}
-
-		public CreatePSBTResponse CreatePSBT(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request,
-			CancellationToken cancellation = default)
+		public CreatePSBTResponse CreatePSBT(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request, CancellationToken cancellation = default)
 		{
 			return CreatePSBTAsync(derivationStrategy, request, cancellation).GetAwaiter().GetResult();
 		}
-
-		public Task<CreatePSBTResponse> CreatePSBTAsync(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request,
-			CancellationToken cancellation = default)
+		public Task<CreatePSBTResponse> CreatePSBTAsync(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request, CancellationToken cancellation = default)
 		{
 			if (derivationStrategy == null)
 				throw new ArgumentNullException(nameof(derivationStrategy));
 			if (request == null)
 				throw new ArgumentNullException(nameof(request));
-			return this.SendAsync<CreatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations/{1}/psbt/create",
-				new object[] {CryptoCode, derivationStrategy}, cancellation);
+			return this.SendAsync<CreatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations/{1}/psbt/create", new object[] { CryptoCode, derivationStrategy }, cancellation);
 		}
 
 		public UpdatePSBTResponse UpdatePSBT(UpdatePSBTRequest request, CancellationToken cancellation = default)
 		{
 			return UpdatePSBTAsync(request, cancellation).GetAwaiter().GetResult();
 		}
-
 		public Task<UpdatePSBTResponse> UpdatePSBTAsync(UpdatePSBTRequest request, CancellationToken cancellation = default)
 		{
 			if (request == null)
 				throw new ArgumentNullException(nameof(request));
-			return this.SendAsync<UpdatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/psbt/update", new object[] {CryptoCode},
-				cancellation);
+			return this.SendAsync<UpdatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/psbt/update", new object[] { CryptoCode }, cancellation);
 		}
-
 		public BroadcastResult Broadcast(Transaction tx, CancellationToken cancellation = default)
 		{
 			return Broadcast(tx, false, cancellation);
 		}
-
 		public BroadcastResult Broadcast(Transaction tx, bool testMempoolAccept, CancellationToken cancellation = default)
 		{
 			return BroadcastAsync(tx, testMempoolAccept, cancellation).GetAwaiter().GetResult();
@@ -584,44 +520,36 @@ namespace NBXplorer
 
 		public Task<BroadcastResult> BroadcastAsync(Transaction tx, bool testMempoolAccept, CancellationToken cancellation = default)
 		{
-			return SendAsync<BroadcastResult>(HttpMethod.Post, tx.ToBytes(), "v1/cryptos/{0}/transactions?testMempoolAccept={1}",
-				new[] {CryptoCode, testMempoolAccept.ToString()}, cancellation);
+			return SendAsync<BroadcastResult>(HttpMethod.Post, tx.ToBytes(), "v1/cryptos/{0}/transactions?testMempoolAccept={1}", new[] { CryptoCode, testMempoolAccept.ToString() }, cancellation);
 		}
 
 		public TMetadata GetMetadata<TMetadata>(DerivationStrategyBase derivationScheme, string key, CancellationToken cancellationToken = default)
 		{
 			return GetMetadataAsync<TMetadata>(derivationScheme, key, cancellationToken).GetAwaiter().GetResult();
 		}
-
-		public Task<TMetadata> GetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key,
-			CancellationToken cancellationToken = default)
+		public Task<TMetadata> GetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key, CancellationToken cancellationToken = default)
 		{
 			if (derivationScheme == null)
 				throw new ArgumentNullException(nameof(derivationScheme));
 			if (key == null)
 				throw new ArgumentNullException(nameof(key));
-			return GetAsync<TMetadata>("v1/cryptos/{0}/derivations/{1}/metadata/{2}", new object[] {CryptoCode, derivationScheme, key},
-				cancellationToken);
+			return GetAsync<TMetadata>("v1/cryptos/{0}/derivations/{1}/metadata/{2}", new object[] { CryptoCode, derivationScheme, key }, cancellationToken);
 		}
 
-		public void SetMetadata<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value,
-			CancellationToken cancellationToken = default)
+		public void SetMetadata<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value, CancellationToken cancellationToken = default)
 		{
 			SetMetadataAsync<TMetadata>(derivationScheme, key, value, cancellationToken).GetAwaiter().GetResult();
 		}
-
-		public Task SetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value,
-			CancellationToken cancellationToken = default)
+		
+		public Task SetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value, CancellationToken cancellationToken = default)
 		{
-			return SendAsync<string>(HttpMethod.Post, value, "v1/cryptos/{0}/derivations/{1}/metadata/{2}",
-				new object[] {CryptoCode, derivationScheme, key}, cancellationToken);
+			return SendAsync<string>(HttpMethod.Post, value, "v1/cryptos/{0}/derivations/{1}/metadata/{2}", new object[] { CryptoCode, derivationScheme, key }, cancellationToken);
 		}
 
 		public Task<GenerateWalletResponse> GenerateWalletAsync(GenerateWalletRequest request = null, CancellationToken cancellationToken = default)
 		{
 			request ??= new GenerateWalletRequest();
-			return SendAsync<GenerateWalletResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations", new object[] {CryptoCode},
-				cancellationToken);
+			return SendAsync<GenerateWalletResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations", new object[] { CryptoCode }, cancellationToken);
 		}
 
 		public GenerateWalletResponse GenerateWallet(GenerateWalletRequest request = null, CancellationToken cancellationToken = default)
@@ -639,21 +567,28 @@ namespace NBXplorer
 		}
 
 		private readonly NBXplorerNetwork _Network;
-
 		public NBXplorerNetwork Network
 		{
-			get { return _Network; }
+			get
+			{
+				return _Network;
+			}
 		}
 
 
 		private readonly Uri _Address;
-
 		public Uri Address
 		{
-			get { return _Address; }
+			get
+			{
+				return _Address;
+			}
 		}
 
-		public bool IncludeTransaction { get; set; } = true;
+		public bool IncludeTransaction
+		{
+			get; set;
+		} = true;
 		public Serializer Serializer { get; private set; }
 
 		internal string GetFullUri(string relativePath, params object[] parameters)
@@ -670,30 +605,25 @@ namespace NBXplorer
 				else
 					uri += $"&includeTransaction=false";
 			}
-
 			return uri;
 		}
-
 		private Task<T> GetAsync<T>(string relativePath, object[] parameters, CancellationToken cancellation)
 		{
 			return SendAsync<T>(HttpMethod.Get, null, relativePath, parameters, cancellation);
 		}
-
 		internal async Task<T> SendAsync<T>(HttpMethod method, object body, string relativePath, object[] parameters, CancellationToken cancellation)
 		{
 			HttpRequestMessage message = CreateMessage(method, body, relativePath, parameters);
 			var result = await Client.SendAsync(message, cancellation).ConfigureAwait(false);
-			if ((int) result.StatusCode == 404)
+			if ((int)result.StatusCode == 404)
 			{
 				return default(T);
 			}
-
-			if (result.StatusCode == HttpStatusCode.GatewayTimeout || result.StatusCode == HttpStatusCode.RequestTimeout)
+			if(result.StatusCode == HttpStatusCode.GatewayTimeout || result.StatusCode == HttpStatusCode.RequestTimeout)
 			{
-				throw new HttpRequestException($"HTTP error {(int) result.StatusCode}", new TimeoutException());
+				throw new HttpRequestException($"HTTP error {(int)result.StatusCode}", new TimeoutException());
 			}
-
-			if ((int) result.StatusCode == 401)
+			if ((int)result.StatusCode == 401)
 			{
 				if (_Auth.RefreshCache())
 				{
@@ -701,7 +631,6 @@ namespace NBXplorer
 					result = await Client.SendAsync(message).ConfigureAwait(false);
 				}
 			}
-
 			return await ParseResponse<T>(result).ConfigureAwait(false);
 		}
 
@@ -713,11 +642,10 @@ namespace NBXplorer
 			if (body != null)
 			{
 				if (body is byte[])
-					message.Content = new ByteArrayContent((byte[]) body);
+					message.Content = new ByteArrayContent((byte[])body);
 				else
 					message.Content = new StringContent(Serializer.ToString(body), Encoding.UTF8, "application/json");
 			}
-
 			return message;
 		}
 
@@ -732,9 +660,8 @@ namespace NBXplorer
 						return Serializer.ToObject<T>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
 					else if (response.Content.Headers.ContentType.MediaType.Equals("application/octet-stream", StringComparison.Ordinal))
 					{
-						return (T) (object) await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+						return (T)(object)await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 					}
-
 				if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError)
 					response.EnsureSuccessStatusCode();
 				var error = Serializer.ToObject<NBXplorerError>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));

--- a/NBXplorer.Client/ExplorerClient.cs
+++ b/NBXplorer.Client/ExplorerClient.cs
@@ -27,6 +27,7 @@ namespace NBXplorer
 			void SetWebSocketAuth(ClientWebSocket socket);
 		}
 
+
 		class CookieAuthentication : IAuth
 		{
 			string _CookieFilePath;
@@ -45,7 +46,10 @@ namespace NBXplorer
 					_CachedAuth = new AuthenticationHeaderValue("Basic", Encoders.Base64.EncodeData(Encoders.ASCII.DecodeData(cookieData)));
 					return true;
 				}
-				catch { return false; }
+				catch
+				{
+					return false;
+				}
 			}
 
 			public void SetAuthorization(HttpRequestMessage message)
@@ -59,6 +63,7 @@ namespace NBXplorer
 					socket.Options.SetRequestHeader("Authorization", $"{_CachedAuth.Scheme} {_CachedAuth.Parameter}");
 			}
 		}
+
 		class NullAuthentication : IAuth
 		{
 			public bool RefreshCache()
@@ -75,7 +80,33 @@ namespace NBXplorer
 			}
 		}
 
-		public ExplorerClient(NBXplorerNetwork network, Uri serverAddress = null)
+		class CustomAuthentication : IAuth
+		{
+			AuthenticationHeaderValue _CachedAuth;
+
+			public CustomAuthentication(AuthenticationHeaderValue authenticationHeader)
+			{
+				_CachedAuth = authenticationHeader;
+			}
+
+			public bool RefreshCache()
+			{
+				return false;
+			}
+
+			public void SetAuthorization(HttpRequestMessage message)
+			{
+				message.Headers.Authorization = _CachedAuth;
+			}
+
+			public void SetWebSocketAuth(ClientWebSocket socket)
+			{
+				if (_CachedAuth != null)
+					socket.Options.SetRequestHeader("Authorization", $"{_CachedAuth.Scheme} {_CachedAuth.Parameter}");
+			}
+		}
+
+		public ExplorerClient(NBXplorerNetwork network, Uri serverAddress = null, AuthenticationHeaderValue customAuthHeader = null)
 		{
 			serverAddress = serverAddress ?? network.DefaultSettings.DefaultUrl;
 			if (network == null)
@@ -85,7 +116,15 @@ namespace NBXplorer
 			Serializer = new Serializer(network);
 			_CryptoCode = _Network.CryptoCode;
 			_Factory = Network.DerivationStrategyFactory;
-			SetCookieAuth(network.DefaultSettings.DefaultCookieFile);
+			if (customAuthHeader == null)
+			{
+				SetCookieAuth(network.DefaultSettings.DefaultCookieFile);
+			}
+			else
+			{
+				_Auth = new CustomAuthentication(customAuthHeader);
+			}
+			
 		}
 
 		internal IAuth _Auth = new NullAuthentication();
@@ -105,19 +144,19 @@ namespace NBXplorer
 		}
 
 		private readonly string _CryptoCode = "BTC";
+
 		public string CryptoCode
 		{
-			get
-			{
-				return _CryptoCode;
-			}
+			get { return _CryptoCode; }
 		}
 
 		DerivationStrategy.DerivationStrategyFactory _Factory;
+
 		public UTXOChanges GetUTXOs(DerivationStrategyBase extKey, CancellationToken cancellation = default)
 		{
 			return GetUTXOsAsync(extKey, cancellation).GetAwaiter().GetResult();
 		}
+
 		public Task<UTXOChanges> GetUTXOsAsync(DerivationStrategyBase extKey, CancellationToken cancellation = default)
 		{
 			if (extKey == null)
@@ -127,7 +166,8 @@ namespace NBXplorer
 
 		public async Task<TransactionResult> GetTransactionAsync(uint256 txId, CancellationToken cancellation = default)
 		{
-			return await SendAsync<TransactionResult>(HttpMethod.Get, null, "v1/cryptos/{0}/transactions/" + txId, new[] { CryptoCode }, cancellation).ConfigureAwait(false);
+			return await SendAsync<TransactionResult>(HttpMethod.Get, null, "v1/cryptos/{0}/transactions/" + txId, new[] {CryptoCode}, cancellation)
+				.ConfigureAwait(false);
 		}
 
 		public TransactionResult GetTransaction(uint256 txId, CancellationToken cancellation = default)
@@ -135,11 +175,13 @@ namespace NBXplorer
 			return GetTransactionAsync(txId, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task<PruneResponse> PruneAsync(DerivationStrategyBase extKey, PruneRequest pruneRequest, CancellationToken cancellation = default)
+		public async Task<PruneResponse> PruneAsync(DerivationStrategyBase extKey, PruneRequest pruneRequest,
+			CancellationToken cancellation = default)
 		{
 			if (extKey == null)
 				throw new ArgumentNullException(nameof(extKey));
-			return await SendAsync<PruneResponse>(HttpMethod.Post, pruneRequest, "v1/cryptos/{0}/derivations/{1}/prune", new object[] { Network.CryptoCode, extKey }, cancellation).ConfigureAwait(false);
+			return await SendAsync<PruneResponse>(HttpMethod.Post, pruneRequest, "v1/cryptos/{0}/derivations/{1}/prune",
+				new object[] {Network.CryptoCode, extKey}, cancellation).ConfigureAwait(false);
 		}
 
 		public PruneResponse Prune(DerivationStrategyBase extKey, PruneRequest pruneRequest, CancellationToken cancellation = default)
@@ -147,7 +189,8 @@ namespace NBXplorer
 			return PruneAsync(extKey, pruneRequest, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task ScanUTXOSetAsync(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null, CancellationToken cancellation = default)
+		public async Task ScanUTXOSetAsync(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null,
+			CancellationToken cancellation = default)
 		{
 			if (extKey == null)
 				throw new ArgumentNullException(nameof(extKey));
@@ -161,16 +204,20 @@ namespace NBXplorer
 			var argsString = string.Join("&", args.ToArray());
 			if (argsString != string.Empty)
 				argsString = $"?{argsString}";
-			await SendAsync<bool>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan{2}", new object[] { Network.CryptoCode, extKey, argsString }, cancellation).ConfigureAwait(false);
+			await SendAsync<bool>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan{2}",
+				new object[] {Network.CryptoCode, extKey, argsString}, cancellation).ConfigureAwait(false);
 		}
-		public void ScanUTXOSet(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null, CancellationToken cancellation = default)
+
+		public void ScanUTXOSet(DerivationStrategyBase extKey, int? batchSize = null, int? gapLimit = null, int? fromIndex = null,
+			CancellationToken cancellation = default)
 		{
 			ScanUTXOSetAsync(extKey, batchSize, gapLimit, fromIndex, cancellation).GetAwaiter().GetResult();
 		}
 
 		public async Task<ScanUTXOInformation> GetScanUTXOSetInformationAsync(DerivationStrategyBase extKey, CancellationToken cancellation = default)
 		{
-			return await SendAsync<ScanUTXOInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan", new object[] { Network.CryptoCode, extKey }, cancellation).ConfigureAwait(false);
+			return await SendAsync<ScanUTXOInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos/scan",
+				new object[] {Network.CryptoCode, extKey}, cancellation).ConfigureAwait(false);
 		}
 
 		public ScanUTXOInformation GetScanUTXOSetInformation(DerivationStrategyBase extKey, CancellationToken cancellation = default)
@@ -199,17 +246,20 @@ namespace NBXplorer
 		{
 			return GetUTXOsAsync(trackedSource, cancellation).GetAwaiter().GetResult();
 		}
+
 		public async Task<UTXOChanges> GetUTXOsAsync(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			if (trackedSource == null)
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos", new object[] { CryptoCode, dsts.DerivationStrategy.ToString() }, cancellation).ConfigureAwait(false);
+				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/utxos",
+					new object[] {CryptoCode, dsts.DerivationStrategy.ToString()}, cancellation).ConfigureAwait(false);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/addresses/{1}/utxos", new object[] { CryptoCode, asts.Address }, cancellation).ConfigureAwait(false);
+				return await SendAsync<UTXOChanges>(HttpMethod.Get, null, "v1/cryptos/{0}/addresses/{1}/utxos",
+					new object[] {CryptoCode, asts.Address}, cancellation).ConfigureAwait(false);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -219,6 +269,7 @@ namespace NBXplorer
 		{
 			WaitServerStartedAsync(cancellation).GetAwaiter().GetResult();
 		}
+
 		public async Task WaitServerStartedAsync(CancellationToken cancellation = default)
 		{
 			while (true)
@@ -230,8 +281,14 @@ namespace NBXplorer
 						break;
 					await Task.Delay(10);
 				}
-				catch (OperationCanceledException) { throw; }
-				catch { }
+				catch (OperationCanceledException)
+				{
+					throw;
+				}
+				catch
+				{
+				}
+
 				cancellation.ThrowIfCancellationRequested();
 			}
 		}
@@ -241,6 +298,7 @@ namespace NBXplorer
 		{
 			TrackAsync(strategy, cancellation).GetAwaiter().GetResult();
 		}
+
 		public Task TrackAsync(DerivationStrategyBase strategy, CancellationToken cancellation = default)
 		{
 			return TrackAsync(TrackedSource.Create(strategy), cancellation);
@@ -250,28 +308,34 @@ namespace NBXplorer
 		{
 			TrackAsync(strategy, trackDerivationRequest, cancellation).GetAwaiter().GetResult();
 		}
-		public async Task TrackAsync(DerivationStrategyBase strategy, TrackWalletRequest trackDerivationRequest, CancellationToken cancellation = default)
+
+		public async Task TrackAsync(DerivationStrategyBase strategy, TrackWalletRequest trackDerivationRequest,
+			CancellationToken cancellation = default)
 		{
 			if (strategy == null)
 				throw new ArgumentNullException(nameof(strategy));
-			await SendAsync<string>(HttpMethod.Post, trackDerivationRequest, "v1/cryptos/{0}/derivations/{1}", new[] { CryptoCode, strategy.ToString() }, cancellation).ConfigureAwait(false);
+			await SendAsync<string>(HttpMethod.Post, trackDerivationRequest, "v1/cryptos/{0}/derivations/{1}",
+				new[] {CryptoCode, strategy.ToString()}, cancellation).ConfigureAwait(false);
 		}
 
 		public void Track(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			TrackAsync(trackedSource, cancellation).GetAwaiter().GetResult();
 		}
+
 		public Task TrackAsync(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			if (trackedSource == null)
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}", new[] { CryptoCode, dsts.DerivationStrategy.ToString() }, cancellation);
+				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/derivations/{1}",
+					new[] {CryptoCode, dsts.DerivationStrategy.ToString()}, cancellation);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/addresses/{1}", new[] { CryptoCode, asts.Address.ToString() }, cancellation);
+				return SendAsync<string>(HttpMethod.Post, null, "v1/cryptos/{0}/addresses/{1}", new[] {CryptoCode, asts.Address.ToString()},
+					cancellation);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -291,14 +355,17 @@ namespace NBXplorer
 		{
 			return GetBalanceAsync(userDerivationScheme).GetAwaiter().GetResult();
 		}
+
 		public Task<GetBalanceResponse> GetBalanceAsync(DerivationStrategyBase userDerivationScheme, CancellationToken cancellation = default)
 		{
-			return SendAsync<GetBalanceResponse>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/balance", new[] { CryptoCode, userDerivationScheme.ToString() }, cancellation);
+			return SendAsync<GetBalanceResponse>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/balance",
+				new[] {CryptoCode, userDerivationScheme.ToString()}, cancellation);
 		}
 
 		public Task CancelReservationAsync(DerivationStrategyBase strategy, KeyPath[] keyPaths, CancellationToken cancellation = default)
 		{
-			return SendAsync<string>(HttpMethod.Post, keyPaths, "v1/cryptos/{0}/derivations/{1}/addresses/cancelreservation", new[] { CryptoCode, strategy.ToString() }, cancellation);
+			return SendAsync<string>(HttpMethod.Post, keyPaths, "v1/cryptos/{0}/derivations/{1}/addresses/cancelreservation",
+				new[] {CryptoCode, strategy.ToString()}, cancellation);
 		}
 
 		public StatusResult GetStatus(CancellationToken cancellation = default)
@@ -310,10 +377,12 @@ namespace NBXplorer
 		{
 			return SendAsync<StatusResult>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/status", null, cancellation);
 		}
+
 		public GetTransactionsResponse GetTransactions(DerivationStrategyBase strategy, CancellationToken cancellation = default)
 		{
 			return GetTransactionsAsync(strategy, cancellation).GetAwaiter().GetResult();
 		}
+
 		public GetTransactionsResponse GetTransactions(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			return GetTransactionsAsync(trackedSource, cancellation).GetAwaiter().GetResult();
@@ -323,17 +392,20 @@ namespace NBXplorer
 		{
 			return GetTransactionsAsync(TrackedSource.Create(strategy), cancellation);
 		}
+
 		public Task<GetTransactionsResponse> GetTransactionsAsync(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{
 			if (trackedSource == null)
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions", null, cancellation);
+				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null,
+					$"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions", null, cancellation);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions", null, cancellation);
+				return SendAsync<GetTransactionsResponse>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions",
+					null, cancellation);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -344,11 +416,15 @@ namespace NBXplorer
 		{
 			return this.GetTransactionAsync(trackedSource, txId, cancellation).GetAwaiter().GetResult();
 		}
-		public TransactionInformation GetTransaction(DerivationStrategyBase derivationStrategyBase, uint256 txId, CancellationToken cancellation = default)
+
+		public TransactionInformation GetTransaction(DerivationStrategyBase derivationStrategyBase, uint256 txId,
+			CancellationToken cancellation = default)
 		{
 			return this.GetTransactionAsync(derivationStrategyBase, txId, cancellation).GetAwaiter().GetResult();
 		}
-		public Task<TransactionInformation> GetTransactionAsync(DerivationStrategyBase derivationStrategyBase, uint256 txId, CancellationToken cancellation = default)
+
+		public Task<TransactionInformation> GetTransactionAsync(DerivationStrategyBase derivationStrategyBase, uint256 txId,
+			CancellationToken cancellation = default)
 		{
 			if (derivationStrategyBase == null)
 				throw new ArgumentNullException(nameof(derivationStrategyBase));
@@ -363,11 +439,13 @@ namespace NBXplorer
 				throw new ArgumentNullException(nameof(trackedSource));
 			if (trackedSource is DerivationSchemeTrackedSource dsts)
 			{
-				return SendAsync<TransactionInformation>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions/{txId}", null, cancellation);
+				return SendAsync<TransactionInformation>(HttpMethod.Get, null,
+					$"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}/transactions/{txId}", null, cancellation);
 			}
 			else if (trackedSource is AddressTrackedSource asts)
 			{
-				return SendAsync<TransactionInformation>(HttpMethod.Get, null, $"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions/{txId}", null, cancellation);
+				return SendAsync<TransactionInformation>(HttpMethod.Get, null,
+					$"v1/cryptos/{CryptoCode}/addresses/{asts.Address}/transactions/{txId}", null, cancellation);
 			}
 			else
 				throw UnSupported(trackedSource);
@@ -385,16 +463,20 @@ namespace NBXplorer
 			RescanAsync(rescanRequest, cancellation).GetAwaiter().GetResult();
 		}
 
-		public KeyPathInformation GetUnused(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0, bool reserve = false, CancellationToken cancellation = default)
+		public KeyPathInformation GetUnused(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0, bool reserve = false,
+			CancellationToken cancellation = default)
 		{
 			return GetUnusedAsync(strategy, feature, skip, reserve, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task<KeyPathInformation> GetUnusedAsync(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0, bool reserve = false, CancellationToken cancellation = default)
+		public async Task<KeyPathInformation> GetUnusedAsync(DerivationStrategyBase strategy, DerivationFeature feature, int skip = 0,
+			bool reserve = false, CancellationToken cancellation = default)
 		{
 			try
 			{
-				return await GetAsync<KeyPathInformation>($"v1/cryptos/{CryptoCode}/derivations/{strategy}/addresses/unused?feature={feature}&skip={skip}&reserve={reserve}", null, cancellation).ConfigureAwait(false);
+				return await GetAsync<KeyPathInformation>(
+					$"v1/cryptos/{CryptoCode}/derivations/{strategy}/addresses/unused?feature={feature}&skip={skip}&reserve={reserve}", null,
+					cancellation).ConfigureAwait(false);
 			}
 			catch (NBXplorerException ex) when (ex.Error?.HttpCode == 404)
 			{
@@ -407,15 +489,18 @@ namespace NBXplorer
 			return GetKeyInformationAsync(strategy, script, cancellation).GetAwaiter().GetResult();
 		}
 
-		public async Task<KeyPathInformation> GetKeyInformationAsync(DerivationStrategyBase strategy, Script script, CancellationToken cancellation = default)
+		public async Task<KeyPathInformation> GetKeyInformationAsync(DerivationStrategyBase strategy, Script script,
+			CancellationToken cancellation = default)
 		{
-			return await SendAsync<KeyPathInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/scripts/" + script.ToHex(), new object[] { CryptoCode, strategy }, cancellation).ConfigureAwait(false);
+			return await SendAsync<KeyPathInformation>(HttpMethod.Get, null, "v1/cryptos/{0}/derivations/{1}/scripts/" + script.ToHex(),
+				new object[] {CryptoCode, strategy}, cancellation).ConfigureAwait(false);
 		}
 
 		[Obsolete("Use GetKeyInformationAsync(DerivationStrategyBase strategy, Script script) instead")]
 		public async Task<KeyPathInformation[]> GetKeyInformationsAsync(Script script, CancellationToken cancellation = default)
 		{
-			return await SendAsync<KeyPathInformation[]>(HttpMethod.Get, null, "v1/cryptos/{0}/scripts/" + script.ToHex(), new[] { CryptoCode }, cancellation).ConfigureAwait(false);
+			return await SendAsync<KeyPathInformation[]>(HttpMethod.Get, null, "v1/cryptos/{0}/scripts/" + script.ToHex(), new[] {CryptoCode},
+				cancellation).ConfigureAwait(false);
 		}
 
 		[Obsolete("Use GetKeyInformation(DerivationStrategyBase strategy, Script script) instead")]
@@ -433,48 +518,60 @@ namespace NBXplorer
 		{
 			return GetFeeRateAsync(blockCount, fallbackFeeRate, cancellation).GetAwaiter().GetResult();
 		}
+
 		public async Task<GetFeeRateResult> GetFeeRateAsync(int blockCount, FeeRate fallbackFeeRate, CancellationToken cancellation = default)
 		{
 			try
 			{
-				return await GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] { CryptoCode, blockCount }, cancellation).ConfigureAwait(false);
+				return await GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] {CryptoCode, blockCount}, cancellation)
+					.ConfigureAwait(false);
 			}
 			catch (NBXplorerException ex) when (fallbackFeeRate != null && ex.Error.Code == "fee-estimation-unavailable")
 			{
-				return new GetFeeRateResult() { BlockCount = blockCount, FeeRate = fallbackFeeRate };
+				return new GetFeeRateResult() {BlockCount = blockCount, FeeRate = fallbackFeeRate};
 			}
 		}
+
 		public Task<GetFeeRateResult> GetFeeRateAsync(int blockCount, CancellationToken cancellation = default)
 		{
-			return GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] { CryptoCode, blockCount }, cancellation);
+			return GetAsync<GetFeeRateResult>("v1/cryptos/{0}/fees/{1}", new object[] {CryptoCode, blockCount}, cancellation);
 		}
-		public CreatePSBTResponse CreatePSBT(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request, CancellationToken cancellation = default)
+
+		public CreatePSBTResponse CreatePSBT(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request,
+			CancellationToken cancellation = default)
 		{
 			return CreatePSBTAsync(derivationStrategy, request, cancellation).GetAwaiter().GetResult();
 		}
-		public Task<CreatePSBTResponse> CreatePSBTAsync(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request, CancellationToken cancellation = default)
+
+		public Task<CreatePSBTResponse> CreatePSBTAsync(DerivationStrategyBase derivationStrategy, CreatePSBTRequest request,
+			CancellationToken cancellation = default)
 		{
 			if (derivationStrategy == null)
 				throw new ArgumentNullException(nameof(derivationStrategy));
 			if (request == null)
 				throw new ArgumentNullException(nameof(request));
-			return this.SendAsync<CreatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations/{1}/psbt/create", new object[] { CryptoCode, derivationStrategy }, cancellation);
+			return this.SendAsync<CreatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations/{1}/psbt/create",
+				new object[] {CryptoCode, derivationStrategy}, cancellation);
 		}
 
 		public UpdatePSBTResponse UpdatePSBT(UpdatePSBTRequest request, CancellationToken cancellation = default)
 		{
 			return UpdatePSBTAsync(request, cancellation).GetAwaiter().GetResult();
 		}
+
 		public Task<UpdatePSBTResponse> UpdatePSBTAsync(UpdatePSBTRequest request, CancellationToken cancellation = default)
 		{
 			if (request == null)
 				throw new ArgumentNullException(nameof(request));
-			return this.SendAsync<UpdatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/psbt/update", new object[] { CryptoCode }, cancellation);
+			return this.SendAsync<UpdatePSBTResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/psbt/update", new object[] {CryptoCode},
+				cancellation);
 		}
+
 		public BroadcastResult Broadcast(Transaction tx, CancellationToken cancellation = default)
 		{
 			return Broadcast(tx, false, cancellation);
 		}
+
 		public BroadcastResult Broadcast(Transaction tx, bool testMempoolAccept, CancellationToken cancellation = default)
 		{
 			return BroadcastAsync(tx, testMempoolAccept, cancellation).GetAwaiter().GetResult();
@@ -487,36 +584,44 @@ namespace NBXplorer
 
 		public Task<BroadcastResult> BroadcastAsync(Transaction tx, bool testMempoolAccept, CancellationToken cancellation = default)
 		{
-			return SendAsync<BroadcastResult>(HttpMethod.Post, tx.ToBytes(), "v1/cryptos/{0}/transactions?testMempoolAccept={1}", new[] { CryptoCode, testMempoolAccept.ToString() }, cancellation);
+			return SendAsync<BroadcastResult>(HttpMethod.Post, tx.ToBytes(), "v1/cryptos/{0}/transactions?testMempoolAccept={1}",
+				new[] {CryptoCode, testMempoolAccept.ToString()}, cancellation);
 		}
 
 		public TMetadata GetMetadata<TMetadata>(DerivationStrategyBase derivationScheme, string key, CancellationToken cancellationToken = default)
 		{
 			return GetMetadataAsync<TMetadata>(derivationScheme, key, cancellationToken).GetAwaiter().GetResult();
 		}
-		public Task<TMetadata> GetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key, CancellationToken cancellationToken = default)
+
+		public Task<TMetadata> GetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key,
+			CancellationToken cancellationToken = default)
 		{
 			if (derivationScheme == null)
 				throw new ArgumentNullException(nameof(derivationScheme));
 			if (key == null)
 				throw new ArgumentNullException(nameof(key));
-			return GetAsync<TMetadata>("v1/cryptos/{0}/derivations/{1}/metadata/{2}", new object[] { CryptoCode, derivationScheme, key }, cancellationToken);
+			return GetAsync<TMetadata>("v1/cryptos/{0}/derivations/{1}/metadata/{2}", new object[] {CryptoCode, derivationScheme, key},
+				cancellationToken);
 		}
 
-		public void SetMetadata<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value, CancellationToken cancellationToken = default)
+		public void SetMetadata<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value,
+			CancellationToken cancellationToken = default)
 		{
 			SetMetadataAsync<TMetadata>(derivationScheme, key, value, cancellationToken).GetAwaiter().GetResult();
 		}
-		
-		public Task SetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value, CancellationToken cancellationToken = default)
+
+		public Task SetMetadataAsync<TMetadata>(DerivationStrategyBase derivationScheme, string key, TMetadata value,
+			CancellationToken cancellationToken = default)
 		{
-			return SendAsync<string>(HttpMethod.Post, value, "v1/cryptos/{0}/derivations/{1}/metadata/{2}", new object[] { CryptoCode, derivationScheme, key }, cancellationToken);
+			return SendAsync<string>(HttpMethod.Post, value, "v1/cryptos/{0}/derivations/{1}/metadata/{2}",
+				new object[] {CryptoCode, derivationScheme, key}, cancellationToken);
 		}
 
 		public Task<GenerateWalletResponse> GenerateWalletAsync(GenerateWalletRequest request = null, CancellationToken cancellationToken = default)
 		{
 			request ??= new GenerateWalletRequest();
-			return SendAsync<GenerateWalletResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations", new object[] { CryptoCode }, cancellationToken);
+			return SendAsync<GenerateWalletResponse>(HttpMethod.Post, request, "v1/cryptos/{0}/derivations", new object[] {CryptoCode},
+				cancellationToken);
 		}
 
 		public GenerateWalletResponse GenerateWallet(GenerateWalletRequest request = null, CancellationToken cancellationToken = default)
@@ -534,28 +639,21 @@ namespace NBXplorer
 		}
 
 		private readonly NBXplorerNetwork _Network;
+
 		public NBXplorerNetwork Network
 		{
-			get
-			{
-				return _Network;
-			}
+			get { return _Network; }
 		}
 
 
 		private readonly Uri _Address;
+
 		public Uri Address
 		{
-			get
-			{
-				return _Address;
-			}
+			get { return _Address; }
 		}
 
-		public bool IncludeTransaction
-		{
-			get; set;
-		} = true;
+		public bool IncludeTransaction { get; set; } = true;
 		public Serializer Serializer { get; private set; }
 
 		internal string GetFullUri(string relativePath, params object[] parameters)
@@ -572,25 +670,30 @@ namespace NBXplorer
 				else
 					uri += $"&includeTransaction=false";
 			}
+
 			return uri;
 		}
+
 		private Task<T> GetAsync<T>(string relativePath, object[] parameters, CancellationToken cancellation)
 		{
 			return SendAsync<T>(HttpMethod.Get, null, relativePath, parameters, cancellation);
 		}
+
 		internal async Task<T> SendAsync<T>(HttpMethod method, object body, string relativePath, object[] parameters, CancellationToken cancellation)
 		{
 			HttpRequestMessage message = CreateMessage(method, body, relativePath, parameters);
 			var result = await Client.SendAsync(message, cancellation).ConfigureAwait(false);
-			if ((int)result.StatusCode == 404)
+			if ((int) result.StatusCode == 404)
 			{
 				return default(T);
 			}
-			if(result.StatusCode == HttpStatusCode.GatewayTimeout || result.StatusCode == HttpStatusCode.RequestTimeout)
+
+			if (result.StatusCode == HttpStatusCode.GatewayTimeout || result.StatusCode == HttpStatusCode.RequestTimeout)
 			{
-				throw new HttpRequestException($"HTTP error {(int)result.StatusCode}", new TimeoutException());
+				throw new HttpRequestException($"HTTP error {(int) result.StatusCode}", new TimeoutException());
 			}
-			if ((int)result.StatusCode == 401)
+
+			if ((int) result.StatusCode == 401)
 			{
 				if (_Auth.RefreshCache())
 				{
@@ -598,6 +701,7 @@ namespace NBXplorer
 					result = await Client.SendAsync(message).ConfigureAwait(false);
 				}
 			}
+
 			return await ParseResponse<T>(result).ConfigureAwait(false);
 		}
 
@@ -609,10 +713,11 @@ namespace NBXplorer
 			if (body != null)
 			{
 				if (body is byte[])
-					message.Content = new ByteArrayContent((byte[])body);
+					message.Content = new ByteArrayContent((byte[]) body);
 				else
 					message.Content = new StringContent(Serializer.ToString(body), Encoding.UTF8, "application/json");
 			}
+
 			return message;
 		}
 
@@ -627,8 +732,9 @@ namespace NBXplorer
 						return Serializer.ToObject<T>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
 					else if (response.Content.Headers.ContentType.MediaType.Equals("application/octet-stream", StringComparison.Ordinal))
 					{
-						return (T)(object)await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+						return (T) (object) await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 					}
+
 				if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError)
 					response.EnsureSuccessStatusCode();
 				var error = Serializer.ToObject<NBXplorerError>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));


### PR DESCRIPTION
Enable passing of custom authentication headers to the client. If NBX is hidden behind a proxy that provides authentication capabilities the cookie authentication is not sufficient. Passing a custom Auth Header allows for different authentication methods via Token, Cookie, HttpBasic, OAuth....

The changes are minimal but enable some customization for users if needed.