### PR TITLE
Add server alias option

### DIFF
--- a/NBXplorer.Client/Models/StatusResult.cs
+++ b/NBXplorer.Client/Models/StatusResult.cs
@@ -69,6 +69,11 @@ namespace NBXplorer.Models
 			get;
 			set;
 		}
+		public string? Alias
+		{
+			get;
+			set;
+		}
 		[JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
 		public NetworkType NetworkType
 		{

--- a/NBXplorer/Configuration/DefaultConfiguration.cs
+++ b/NBXplorer/Configuration/DefaultConfiguration.cs
@@ -64,6 +64,7 @@ namespace NBXplorer.Configuration
 			app.Option("--mingapsize", $"The minimum gap address count on which the explorer will track derivation schemes (default: 20)", CommandOptionType.SingleValue);
 			app.Option("--signalfilesdir", $"The directory where files signaling if a chain is ready is created (default: the network specific datadir)", CommandOptionType.SingleValue);
 			app.Option("--noauth", $"Disable cookie authentication", CommandOptionType.BoolValue);
+			app.Option("--serveralias", $"Define an alias for this server that, if not null, will show in status response (default: empty)", CommandOptionType.SingleValue);
 			app.Option("--cachechain", $"Whether the chain of header is locally cached for faster startup (default: true)", CommandOptionType.SingleValue);
 			app.Option("--rpcnotest", $"Faster start because RPC connection testing skipped (default: false)", CommandOptionType.SingleValue);
 			app.Option("--exposerpc", $"Expose the node RPC through the REST API (default: false)", CommandOptionType.SingleValue);
@@ -150,6 +151,8 @@ namespace NBXplorer.Configuration
 			}
 			builder.AppendLine("## Disable cookie, local ip authorization (unsecured)");
 			builder.AppendLine("#noauth=0");
+			builder.AppendLine("## Add a server alias to be returned in status response");
+			builder.AppendLine("#serveralias=my_business_nbxplorer");
 			builder.AppendLine("## Expose the node RPC through the REST API");
 			builder.AppendLine($"#exposerpc=0");
 			builder.AppendLine("## What crypto currencies is supported");

--- a/NBXplorer/Configuration/ExplorerConfiguration.cs
+++ b/NBXplorer/Configuration/ExplorerConfiguration.cs
@@ -175,6 +175,7 @@ namespace NBXplorer.Configuration
 			CacheChain = config.GetOrDefault<bool>("cachechain", true);
 			ExposeRPC = config.GetOrDefault<bool>("exposerpc", false);
 			NoAuthentication = config.GetOrDefault<bool>("noauth", false);
+			ServerAlias = config.GetOrDefault<string>("serveralias", null);
 
 			var customKeyPathTemplate = config.GetOrDefault<string>("customkeypathtemplate", null);
 			if (!string.IsNullOrEmpty(customKeyPathTemplate))
@@ -222,6 +223,11 @@ namespace NBXplorer.Configuration
 			set;
 		}
 		public bool NoAuthentication
+		{
+			get;
+			set;
+		}
+		public string ServerAlias
 		{
 			get;
 			set;

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -237,7 +237,8 @@ namespace NBXplorer.Controllers
 				CryptoCode = network.CryptoCode,
 				Version = typeof(MainController).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version,
 				SupportedCryptoCodes = Waiters.All().Select(w => w.Network.CryptoCode).ToArray(),
-				IsFullySynched = true
+				IsFullySynched = true,
+				Alias = ExplorerConfiguration.ServerAlias
 			};
 
 			GetNetworkInfoResponse networkInfo = waiter.NetworkInfo;


### PR DESCRIPTION
Adding it to HTTP response was too hard for me. (Microsoft documentation is a jungle)

If you can easily change this to be a HTTP response header for all endpoints that should work too.