### PR TITLE
Allow attempting to set the full tx for segwit inputs

### DIFF
--- a/NBXplorer.Client/Models/CreatePSBTRequest.cs
+++ b/NBXplorer.Client/Models/CreatePSBTRequest.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -78,6 +78,11 @@ namespace NBXplorer.Models
 		/// Disabling the randomization of unspecified parameters to match the network's fingerprint distribution
 		/// </summary>
 		public bool? DisableFingerprintRandomization { get; set; }
+		
+		/// <summary>
+		/// Attempt setting non_witness_utxo for all inputs even if they are segwit.
+		/// </summary>
+		public bool TrySetFullUTXOTransaction { get; set; }
 	}
 	public class PSBTRebaseKeyRules
 	{

--- a/NBXplorer.Client/Models/CreatePSBTRequest.cs
+++ b/NBXplorer.Client/Models/CreatePSBTRequest.cs
@@ -82,7 +82,7 @@ namespace NBXplorer.Models
 		/// <summary>
 		/// Attempt setting non_witness_utxo for all inputs even if they are segwit.
 		/// </summary>
-		public bool TrySetFullUTXOTransaction { get; set; }
+		public bool AlwaysIncludeNonWitnessUTXO { get; set; }
 	}
 	public class PSBTRebaseKeyRules
 	{

--- a/NBXplorer.Client/Models/RescanRequest.cs
+++ b/NBXplorer.Client/Models/RescanRequest.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/NBXplorer.Client/Models/UpdatePSBTRequest.cs
+++ b/NBXplorer.Client/Models/UpdatePSBTRequest.cs
@@ -24,7 +24,7 @@ namespace NBXplorer.Models
 		/// <summary>
 		/// Attempt setting non_witness_utxo for all inputs even if they are segwit.
 		/// </summary>
-		public bool TrySetFullUTXOTransaction { get; set; }
+		public bool AlwaysIncludeNonWitnessUTXO { get; set; }
 	}
 	public class UpdatePSBTResponse
 	{

--- a/NBXplorer.Client/Models/UpdatePSBTRequest.cs
+++ b/NBXplorer.Client/Models/UpdatePSBTRequest.cs
@@ -20,6 +20,11 @@ namespace NBXplorer.Models
 		/// This transform (PubKey0, 0/0, accountFingerprint) by (PubKey0, m/49'/0'/0/0, masterFingerprint) 
 		/// </summary>
 		public List<PSBTRebaseKeyRules> RebaseKeyPaths { get; set; }
+		
+		/// <summary>
+		/// Attempt setting non_witness_utxo for all inputs even if they are segwit.
+		/// </summary>
+		public bool TrySetFullUTXOTransaction { get; set; }
 	}
 	public class UpdatePSBTResponse
 	{

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -842,6 +842,32 @@ namespace NBXplorer.Tests
 			});
 			Assert.True(psbt2.PSBT.TryGetEstimatedFeeRate(out var feeRate));
 			Assert.Equal(new FeeRate(1.0m), feeRate);
+
+			if (segwit)
+			{
+				// some PSBT signers are incompliant with spec and require the non_witness_utxo even for segwit inputs
+			
+				Logs.Tester.LogInformation("Let's check that if we can create or update a psbt with non_witness_utxo filled even for segwit inputs");
+				psbt2 = tester.Client.CreatePSBT(userDerivationScheme, new CreatePSBTRequest()
+				{
+					Destinations =
+					{
+						new CreatePSBTDestination()
+						{
+							Destination = newAddress.Address,
+							Amount = Money.Coins(0.0001m)
+						}
+					},
+					TrySetFullUTXOTransaction = true
+				});
+
+				//in our case, we should have the tx to load this, but if someone restored the wallet and has a pruned node, this may not be set 
+				foreach (var psbtInput in psbt2.PSBT.Inputs)
+				{
+					Assert.NotNull(psbtInput.NonWitnessUtxo);
+				}
+			}
+			
 		}
 
 		[Fact]

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -858,7 +858,11 @@ namespace NBXplorer.Tests
 							Amount = Money.Coins(0.0001m)
 						}
 					},
-					TrySetFullUTXOTransaction = true
+					FeePreference = new FeePreference()
+					{
+						FallbackFeeRate = new FeeRate(1.0m)
+					},
+					AlwaysIncludeNonWitnessUTXO = true
 				});
 
 				//in our case, we should have the tx to load this, but if someone restored the wallet and has a pruned node, this may not be set 

--- a/NBXplorer/Controllers/MainController.PSBT.cs
+++ b/NBXplorer/Controllers/MainController.PSBT.cs
@@ -282,7 +282,7 @@ namespace NBXplorer.Controllers
 				DerivationScheme = strategy,
 				PSBT = psbt,
 				RebaseKeyPaths = request.RebaseKeyPaths,				
-				TrySetFullUTXOTransaction = request.TrySetFullUTXOTransaction
+				AlwaysIncludeNonWitnessUTXO = request.AlwaysIncludeNonWitnessUTXO
 			};
 			await UpdatePSBTCore(update, network);
 			var resp = new CreatePSBTResponse()
@@ -324,7 +324,7 @@ namespace NBXplorer.Controllers
 				await UpdateHDKeyPathsWitnessAndRedeem(update, repo);
 			}
 
-			if (!update.TrySetFullUTXOTransaction)
+			if (!update.AlwaysIncludeNonWitnessUTXO)
 			{
 				foreach (var input in update.PSBT.Inputs)
 					input.TrySlimUTXO();
@@ -438,7 +438,7 @@ namespace NBXplorer.Controllers
 			{
 				AnnotatedTransactionCollection txs = null;
 				// First, we check for data in our history
-				foreach (var input in update.PSBT.Inputs.Where(psbtInput => update.TrySetFullUTXOTransaction || NeedUTXO(psbtInput)))
+				foreach (var input in update.PSBT.Inputs.Where(psbtInput => update.AlwaysIncludeNonWitnessUTXO || NeedUTXO(psbtInput)))
 				{
 					txs = txs ?? await GetAnnotatedTransactions(repo, ChainProvider.GetChain(repo.Network), new DerivationSchemeTrackedSource(derivationScheme));
 					if (txs.GetByTxId(input.PrevOut.Hash) is AnnotatedTransaction tx)
@@ -458,7 +458,7 @@ namespace NBXplorer.Controllers
 
 			// then, we search data in the saved transactions
 			await Task.WhenAll(update.PSBT.Inputs
-							.Where(psbtInput => update.TrySetFullUTXOTransaction || NeedUTXO(psbtInput))
+							.Where(psbtInput => update.AlwaysIncludeNonWitnessUTXO || NeedUTXO(psbtInput))
 							.Select(async (input) =>
 							{
 								// If this is not segwit, or we are unsure of it, let's try to grab from our saved transactions
@@ -477,7 +477,7 @@ namespace NBXplorer.Controllers
 			{
 				var batch = rpc.RPC.PrepareBatch();
 				var getTransactions = Task.WhenAll(update.PSBT.Inputs
-					.Where(psbtInput => update.TrySetFullUTXOTransaction || NeedUTXO(psbtInput))
+					.Where(psbtInput => update.AlwaysIncludeNonWitnessUTXO || NeedUTXO(psbtInput))
 					.Where(input => input.NonWitnessUtxo == null)
 					.Select(async input =>
 				   {

--- a/docs/API.md
+++ b/docs/API.md
@@ -953,7 +953,8 @@ Fields:
 		"accountKeyPath": "ab5ed9ab/49'/0'/0'"
 	  }
   ],
-  "disableFingerprintRandomization": false
+  "disableFingerprintRandomization": false,
+  "trySetFullUTXOTransaction": false
 }
 ```
 
@@ -982,6 +983,7 @@ Fields:
 * `rebaseKeyPaths[].accountKey`: The account key to rebase
 * `rebaseKeyPaths[].accountKeyPath`: The path from the root to the account key prefixed by the master public key fingerprint.
 * `disableFingerprintRandomization`: Disable the randomization of default parameter's value to match the network's fingerprint distribution. (randomized default values are `version`, `timeLock`, `rbf`, `discourageFeeSniping`)
+* `trySetFullUTXOTransaction`: Try to set the full transaction in `non_witness_utxo`, even for segwit inputs (default to `false`)
 
 Response:
 
@@ -1026,6 +1028,7 @@ NBXplorer will take to complete as much information as it can about this PSBT.
 * `rebaseKeyPaths`: Optional. Rebase the hdkey paths (if no rebase, the key paths are relative to the xpub that NBXplorer knows about), a rebase can transform (PubKey0, 0/0, accountFingerprint) by (PubKey0, m/49'/0'/0/0, masterFingerprint)
 * `rebaseKeyPaths[].accountKey`: The account key to rebase
 * `rebaseKeyPaths[].accountKeyPath`: The path from the root to the account key prefixed by the master public key fingerprint.
+* `trySetFullUTXOTransaction`: Try to set the full transaction in `non_witness_utxo`, even for segwit inputs (default to `false`)
 
 Response:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -954,7 +954,7 @@ Fields:
 	  }
   ],
   "disableFingerprintRandomization": false,
-  "trySetFullUTXOTransaction": false
+  "alwaysIncludeNonWitnessUTXO": false
 }
 ```
 
@@ -983,7 +983,7 @@ Fields:
 * `rebaseKeyPaths[].accountKey`: The account key to rebase
 * `rebaseKeyPaths[].accountKeyPath`: The path from the root to the account key prefixed by the master public key fingerprint.
 * `disableFingerprintRandomization`: Disable the randomization of default parameter's value to match the network's fingerprint distribution. (randomized default values are `version`, `timeLock`, `rbf`, `discourageFeeSniping`)
-* `trySetFullUTXOTransaction`: Try to set the full transaction in `non_witness_utxo`, even for segwit inputs (default to `false`)
+* `alwaysIncludeNonWitnessUTXO`: Try to set the full transaction in `non_witness_utxo`, even for segwit inputs (default to `false`)
 
 Response:
 
@@ -1028,7 +1028,7 @@ NBXplorer will take to complete as much information as it can about this PSBT.
 * `rebaseKeyPaths`: Optional. Rebase the hdkey paths (if no rebase, the key paths are relative to the xpub that NBXplorer knows about), a rebase can transform (PubKey0, 0/0, accountFingerprint) by (PubKey0, m/49'/0'/0/0, masterFingerprint)
 * `rebaseKeyPaths[].accountKey`: The account key to rebase
 * `rebaseKeyPaths[].accountKeyPath`: The path from the root to the account key prefixed by the master public key fingerprint.
-* `trySetFullUTXOTransaction`: Try to set the full transaction in `non_witness_utxo`, even for segwit inputs (default to `false`)
+* `alwaysIncludeNonWitnessUTXO`: Try to set the full transaction in `non_witness_utxo`, even for segwit inputs (default to `false`)
 
 Response:
 ```json


### PR DESCRIPTION
An new option to allow *attempting* to set `non_witness_utxo` for segwit inputs on PSBT create/update.