### PR TITLE
Allow GetEvents to fetch limit events from latest

### DIFF
--- a/NBXplorer.Client/LongPollingNotificationSession.cs
+++ b/NBXplorer.Client/LongPollingNotificationSession.cs
@@ -84,5 +84,24 @@ namespace NBXplorer
 					  .ToArray();
 			return evtsObj;
 		}
+
+		public NewEventBase[] GetLatestEvents(int limit = 10, CancellationToken cancellation = default)
+		{
+			return GetLatestEventsAsync(limit, cancellation).GetAwaiter().GetResult();
+		}
+
+		public async Task<NewEventBase[]> GetLatestEventsAsync(int limit = 10, CancellationToken cancellation = default)
+		{
+			List<string> parameters = new List<string>();
+			if (limit != 10)
+				parameters.Add($"limit={limit}");
+			var parametersString = parameters.Count == 0 ? string.Empty : $"?{String.Join("&", parameters.ToArray<object>())}";
+			var evts = await Client.SendAsync<JArray>(HttpMethod.Get, null, $"v1/cryptos/{Client.CryptoCode}/events/latest{parametersString}", null, cancellation);
+
+			var evtsObj = evts.Select(ev => NewEventBase.ParseEvent((JObject)ev, Client.Serializer.Settings))
+					  .OfType<NewEventBase>()
+					  .ToArray();
+			return evtsObj;
+		}
 	}
 }

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -134,6 +134,27 @@ namespace NBXplorer.Tests
 				}
 				evts = await tester.Repository.GetEvents(0);
 				Assert.Equal(23, evts.Count);
+
+				// Test GetLatestEvents
+				var latestEvtsNoArg = await tester.Repository.GetLatestEvents();
+				Assert.Equal(10, latestEvtsNoArg.Count);
+				Assert.Equal(14, ((NewBlockEvent)latestEvtsNoArg[0]).Height);
+				Assert.Equal(23, ((NewBlockEvent)latestEvtsNoArg[9]).Height);
+
+				var latestEvts1 = await tester.Repository.GetLatestEvents(1);
+				Assert.Equal(1, latestEvts1.Count);
+				Assert.Equal(23, ((NewBlockEvent)latestEvts1[0]).Height);
+
+				var latestEvts10 = await tester.Repository.GetLatestEvents(10);
+				Assert.Equal(10, latestEvts10.Count);
+				Assert.Equal(14, ((NewBlockEvent)latestEvts10[0]).Height);
+				Assert.Equal(23, ((NewBlockEvent)latestEvts10[9]).Height);
+
+				var latestEvts50 = await tester.Repository.GetLatestEvents(50);
+				Assert.Equal(23, latestEvts50.Count);
+				Assert.Equal(1, ((NewBlockEvent)latestEvts50[0]).Height);
+				Assert.Equal(23, ((NewBlockEvent)latestEvts50[22]).Height);
+
 				int prev = 0;
 				foreach (var item in evts)
 				{

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -429,7 +429,7 @@ namespace NBXplorer.Controllers
 		[Route("cryptos/{cryptoCode}/events")]
 		public async Task<JArray> GetEvents(string cryptoCode, int lastEventId = 0, int? limit = null, bool longPolling = false, CancellationToken cancellationToken = default)
 		{
-			if (limit != null && limit.Value < 0)
+			if (limit != null && limit.Value < 1)
 				throw new NBXplorerError(400, "invalid-limit", "limit should be more than 0").AsException();
 			var network = GetNetwork(cryptoCode, false);
 			TaskCompletionSource<bool> waitNextEvent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -459,6 +459,18 @@ namespace NBXplorer.Controllers
 				}
 				return new JArray(result.Select(o => o.ToJObject(repo.Serializer.Settings)));
 			}
+		}
+
+
+		[Route("cryptos/{cryptoCode}/events/latest")]
+		public async Task<JArray> GetLatestEvents(string cryptoCode, int limit = 10)
+		{
+			if (limit < 1)
+				throw new NBXplorerError(400, "invalid-limit", "limit should be more than 0").AsException();
+			var network = GetNetwork(cryptoCode, false);
+			var repo = RepositoryProvider.GetRepository(network);
+			var result = await repo.GetLatestEvents(limit);
+			return new JArray(result.Select(o => o.ToJObject(repo.Serializer.Settings)));
 		}
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,6 +27,7 @@ NBXplorer does not index the whole blockchain, rather, it listens transactions a
 * [Get fee rate](#feerate)
 * [Scan UTXO Set](#scanUtxoSet)
 * [Query event stream](#eventStream)
+* [Query event stream from most recent](#eventStreamLatest)
 * [Create Partially Signed Bitcoin Transaction](#psbt)
 * [Update Partially Signed Bitcoin Transaction](#updatepsbt)
 * [Attach metadata to a derivation scheme](#metadata)
@@ -901,6 +902,16 @@ The smallest `eventId` is 1.
   }
 ]
 ```
+
+## <a name="eventStreamLatest"></a>Query event stream (from most recent)
+
+Exact same as [event stream](#eventStream) but it returns a maximum number `#limit` of the most recent events.
+
+HTTP GET v1/cryptos/{cryptoCode}/events/latest
+
+Query parameters:
+
+* `limit`: Limit the maximum number of events to return (default: 10)
 
 ## <a name="psbt"></a>Create Partially Signed Bitcoin Transaction
 


### PR DESCRIPTION
I first separated into 2 different endpoints in commit d2c0a7a but then decided to just add a getLatest parameter.

This is useful for when you might have tons of events, and your client lost its state, but you decide "if we lose state on the client, we should only care about the most recent X events."

Currently, you must get all events to find the last event id.

Alternative solution:

Add new endpoint that will get the latest eventID from the server.