### PR TITLE
Use NBitcoin level CryptoCode for GRS

### DIFF
--- a/NBXplorer.Client/NBXplorerNetworkProvider.Groestlcoin.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Groestlcoin.cs
@@ -15,5 +15,10 @@ namespace NBXplorer
 				CoinType = NetworkType == NetworkType.Mainnet ? new KeyPath("17'") : new KeyPath("1'")
 			});
 		}
+
+		public NBXplorerNetwork GetGRS()
+		{
+			return GetFromCryptoCode(NBitcoin.Altcoins.Groestlcoin.Instance.CryptoCode);
+		}
 	}
 }


### PR DESCRIPTION
Not sure if this is correct or should not be merged.
I am trying to debug importing an ypub and zpub issue for GRS on https://www.grspay.com and saw this missing. Not sure if this related to the issue I am having.

Currently I can only succesfully import xpub for GRS (mainnet and testnet). When importing an ypub and zpub I get the error:  `Invalid Derivation Scheme`
When I convert the ypub and zpub to xpub (by changing the version byte) through: https://groestlcoin.org/xpub-converter/ then it recognises the bech32 address and works.
