### PR TITLE
Document and properly test immature transaction handling

### DIFF
--- a/NBXplorer.Client/Models/GetBalanceResponse.cs
+++ b/NBXplorer.Client/Models/GetBalanceResponse.cs
@@ -7,9 +7,26 @@ namespace NBXplorer.Models
 {
 	public class GetBalanceResponse
 	{
+		/// <summary>
+		/// How the confirmed balance would be updated once all the unconfirmed transactions were confirmed.
+		/// </summary>
 		public IMoney Unconfirmed { get; set; }
+		/// <summary>
+		/// The balance of all funds in confirmed transactions.
+		/// </summary>
 		public IMoney Confirmed { get; set; }
-		public IMoney Immature { get; set; }
+		/// <summary>
+		/// The total of funds owned (ie, `confirmed + unconfirmed`)
+		/// </summary>
 		public IMoney Total { get; set; }
+		/// <summary>
+		/// The total unspendable funds (ie, coinbase reward which need 100 confirmations before being spendable)
+		/// </summary>
+		public IMoney Immature { get; set; }
+
+		/// <summary>
+		/// The total spendable balance. (ie, `total - immature`)
+		/// </summary>
+		public IMoney Available { get; set; }
 	}
 }

--- a/NBXplorer.Tests/Extensions.cs
+++ b/NBXplorer.Tests/Extensions.cs
@@ -36,12 +36,11 @@ namespace NBXplorer.Tests
 				}
 			}
 		}
-
-		public static void WaitForBlocks(this LongPollingNotificationSession session, params uint256[] txIds)
+		public static void WaitForBlocks(this LongPollingNotificationSession session, params uint256[] blockIds)
 		{
-			if (txIds == null || txIds.Length == 0)
+			if (blockIds == null || blockIds.Length == 0)
 				return;
-			HashSet<uint256> txidsSet = new HashSet<uint256>(txIds);
+			HashSet<uint256> txidsSet = new HashSet<uint256>(blockIds);
 			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
 			{
 				while (true)

--- a/NBXplorer/AnnotatedTransactionCollection.cs
+++ b/NBXplorer/AnnotatedTransactionCollection.cs
@@ -204,9 +204,8 @@ namespace NBXplorer
 			{
 				if (tx.Height is int)
 				{
-					if(tx.IsMature)
-						ConfirmedTransactions.Add(tx);
-					else
+					ConfirmedTransactions.Add(tx);
+					if (!tx.IsMature)
 						ImmatureTransactions.Add(tx);
 				}
 				else

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -858,9 +858,10 @@ namespace NBXplorer.Controllers
 			{
 				Confirmed = CalculateBalance(network, transactions.ConfirmedTransactions),
 				Unconfirmed = CalculateBalance(network, transactions.UnconfirmedTransactions),
-				Immature = CalculateBalance(network,transactions.ImmatureTransactions),
-			};
-			balance.Total = balance.Confirmed.Add(balance.Unconfirmed).Add(balance.Immature);
+				Immature = CalculateBalance(network, transactions.ImmatureTransactions)
+		};
+			balance.Total = balance.Confirmed.Add(balance.Unconfirmed);
+			balance.Available = balance.Total.Sub(balance.Immature);
 			return Json(balance, jsonResult.SerializerSettings);
 		}
 

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFramework>
-    <Version>2.1.53</Version>
+    <Version>2.1.54</Version>
 	  <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\NBXplorer.xml</DocumentationFile>
 	  <NoWarn>1701;1702;1705;1591;CS1591</NoWarn>
 	  <LangVersion>8.0</LangVersion>

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,8 +19,8 @@ NBXplorer does not index the whole blockchain, rather, it listens transactions a
 * [Get connection status to the chain](#status)
 * [Get a new unused address](#unused)
 * [Get scriptPubKey information of a Derivation Scheme](#scriptPubKey)
-* [Get Unspent Transaction Outputs (UTXOs)](#utxos)
-* [Get Unspent Transaction Outputs of a specific address](#address-utxos)
+* [Get available Unspent Transaction Outputs (UTXOs)](#utxos)
+* [Get available Unspent Transaction Outputs of a specific address](#address-utxos)
 * [Notifications via websocket](#websocket)
 * [Broadcast a transaction](#broadcast)
 * [Rescan a transaction](#rescan)
@@ -233,15 +233,20 @@ Returns:
         "replacedBy": "7ec0bcbd3b7685b6bbdb4287a250b64bfcb799dbbbcffa78c00e6cc11185e5f1"
       }
     ]
-  }
+  },
+  "immatureTransactions": {
+    "transactions": []
+   }
 }
 ```
 
 * `replaceable`: `true` if the transaction can be replaced (the transaction has RBF activated, is in the unconfirmed list and is not an intermediate transaction in a chain of unconfirmed transaction)
 * `replacing`: Only set in the unconfirmed list, and is pointing to a transaction id in the replaced list.
 * `replacedBy`: Only set in the replaced list, and is pointing to a transaction id in the unconfirmed list. 
+* `immatureTransactions`: Coinbase transactions with less than 100 confirmations.
 
 Note for liquid, `balanceChange` is an array of [AssetMoney](#liquid).
+Note that the list of confirmed transaction also include immature transactions.
 
 ## <a name="address-transactions"></a>Query transactions associated to a specific address
 
@@ -351,10 +356,20 @@ Returns:
 {
   "unconfirmed": 110000000,
   "confirmed": 100000000,
+  "available": 210000000,
+  "immature": 0,
   "total": 210000000
 }
 ```
 Note for liquid, the values are array of [AssetMoney](#liquid).
+
+* `unconfirmed`: How the confirmed balance would be updated once all the unconfirmed transactions were confirmed.
+* `confirmed`: The balance of all funds in confirmed transactions.
+* `total`: The total of funds owned (ie, `confirmed + unconfirmed`)
+* `immature`: The total unspendable funds (ie, coinbase reward which need 100 confirmations before being spendable)
+* `available`: The total spendable balance. (ie, `total - immature`)
+
+Immature funds is the sum of UTXO's belonging to a coinbase transaction with less than 100 confirmations.
 
 ## <a name="gettransaction"></a>Get a transaction
 
@@ -470,7 +485,7 @@ Returns:
 }
 ```
 
-## <a name="utxos"></a>Get Unspent Transaction Outputs (UTXOs)
+## <a name="utxos"></a>Get available Unspent Transaction Outputs (UTXOs)
 
 HTTP GET v1/cryptos/{cryptoCode}/derivations/{derivationScheme}/utxos
 
@@ -526,8 +541,9 @@ Result:
 ```
 
 This call does not returns conflicted unconfirmed UTXOs.
+Note that confirmed utxo, do not include immature UTXOs. (ie. UTXOs belonging to a coinbase transaction with less than 100 confirmations)
 
-## <a name="address-utxos"></a>Get Unspent Transaction Outputs of a specific address
+## <a name="address-utxos"></a>Get available Unspent Transaction Outputs of a specific address
 
 Assuming you use Track on this specific address:
 


### PR DESCRIPTION
https://github.com/dgarage/NBXplorer/issues/321
Ping @sageprogrammer

What do you think of this API?

Technically, immature UTXO and transactions are "Confirmed".
That said, in 99.9999% of cases, what people want when they say "confirmed" they mean "funds we can spend".

I thought including immature transactions in confirmed transactions. But then it would have been confusing: Why the confirmed utxo doesn't include immature utxos, but confirmed transactions does?