### PR TITLE
Get keyPathInformations from OutPoints

### DIFF
--- a/NBXplorer/Repository.cs
+++ b/NBXplorer/Repository.cs
@@ -656,8 +656,8 @@ namespace NBXplorer
 			using var tx = await engine.OpenTransaction();
 			foreach (var info in keyPathInformations)
 			{
-				var bytes = ToBytes(info);
 				var (outPoint, keyInfo) = info;
+				var bytes = ToBytes(keyInfo);
 				await GetOutPointsIndex(tx, outPoint).Insert($"{keyInfo.DerivationStrategy.GetHash()}-{keyInfo.Feature}", bytes);
 			}
 			await tx.Commit();

--- a/NBXplorer/Repository.cs
+++ b/NBXplorer/Repository.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using NBitcoin;
 using System;
@@ -407,6 +407,10 @@ namespace NBXplorer
 			return new Index(tx, $"{_Suffix}Scripts", $"{scriptPubKey.Hash}");
 		}
 
+		Index GetOutPointsIndex(DBTrie.Transaction tx, OutPoint outPoint)
+		{
+			return new Index(tx, $"{_Suffix}OutPoints", $"{outPoint}");
+		}
 		Index GetHighestPathIndex(DBTrie.Transaction tx, DerivationStrategyBase strategy, DerivationFeature feature)
 		{
 			return new Index(tx, $"{_Suffix}HighestPath", $"{strategy.GetHash()}-{feature}");

--- a/NBXplorer/Repository.cs
+++ b/NBXplorer/Repository.cs
@@ -772,10 +772,10 @@ namespace NBXplorer
 				var date = NBitcoin.Utils.DateTimeToUnixTime(now);
 				foreach (var btx in batch)
 				{
-					for (int i = 0; i < btx.Outputs.Count; ++i)
+					foreach (var coin in btx.Outputs.AsCoins())
 					{
-						scripts.Add(btx.Outputs[i].ScriptPubKey);
-						outPointToPubScript.Add(new OutPoint(btx, i), btx.Outputs[i].ScriptPubKey);
+						scripts.Add(coin.ScriptPubKey);
+						outPointToPubScript.Add(coin.Outpoint,coin.ScriptPubKey);
 					}
 					var timestamped = new TimeStampedTransaction(btx, date);
 					var value = timestamped.ToBytes();

--- a/NBXplorer/Repository.cs
+++ b/NBXplorer/Repository.cs
@@ -651,6 +651,17 @@ namespace NBXplorer
 			}
 			await tx.Commit();
 		}
+		public async Task SaveKeyInformations((OutPoint, KeyPathInformation)[] keyPathInformations)
+		{
+			using var tx = await engine.OpenTransaction();
+			foreach (var info in keyPathInformations)
+			{
+				var bytes = ToBytes(info);
+				var (outPoint, keyInfo) = info;
+				await GetOutPointsIndex(tx, outPoint).Insert($"{keyInfo.DerivationStrategy.GetHash()}-{keyInfo.Feature}", bytes);
+			}
+			await tx.Commit();
+		}
 
 		public async Task Track(IDestination address)
 		{

--- a/NBXplorer/Repository.cs
+++ b/NBXplorer/Repository.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using NBitcoin;
 using System;
@@ -658,7 +658,10 @@ namespace NBXplorer
 			{
 				var (outPoint, keyInfo) = info;
 				var bytes = ToBytes(keyInfo);
-				await GetOutPointsIndex(tx, outPoint).Insert($"{keyInfo.DerivationStrategy.GetHash()}-{keyInfo.Feature}", bytes);
+				if(keyInfo.DerivationStrategy is null)
+					await GetOutPointsIndex(tx, outPoint).Insert(keyInfo.ScriptPubKey.Hash.ToString(), bytes);
+				else
+					await GetOutPointsIndex(tx, outPoint).Insert($"{keyInfo.DerivationStrategy.GetHash()}-{keyInfo.Feature}", bytes);
 			}
 			await tx.Commit();
 		}

--- a/NBXplorer/ScanUTXOSetService.cs
+++ b/NBXplorer/ScanUTXOSetService.cs
@@ -287,9 +287,9 @@ namespace NBXplorer
 					return p.KeyPath.Indexes.Last() <= highest.Value;
 				}).ToArray());
 			
-			await repo.SaveKeyInformations(
+			await repo.SaveOutPointToScript(
 				outputs.Select( 
-					o => (o.Coin.Outpoint,scannedItems.KeyPathInformations[o.Coin.ScriptPubKey])
+					o => (o.Coin.Outpoint,o.Coin.ScriptPubKey)
 				).ToArray()
 			);
 			await repo.UpdateAddressPool(trackedSource, progressObj.HighestKeyIndexFound);

--- a/NBXplorer/ScanUTXOSetService.cs
+++ b/NBXplorer/ScanUTXOSetService.cs
@@ -286,6 +286,12 @@ namespace NBXplorer
 						return false;
 					return p.KeyPath.Indexes.Last() <= highest.Value;
 				}).ToArray());
+			
+			await repo.SaveKeyInformations(
+				outputs.Select( 
+					o => (o.Coin.Outpoint,scannedItems.KeyPathInformations[o.Coin.ScriptPubKey])
+				).ToArray()
+			);
 			await repo.UpdateAddressPool(trackedSource, progressObj.HighestKeyIndexFound);
 			await gettingBlockHeaders;
 			DateTimeOffset now = DateTimeOffset.UtcNow;


### PR DESCRIPTION
Since in case of taproots it will not be possible to get `KeyPathInformation` from `SigScript` as was the case before. This pull request allows getting `KeyPathInformation`s from `OutPoint`s using 
- `OutPoint -> PubScript` : newly created index which stores a mapping of `OutPoint` and the corresponding `PubScript`.
- `PubScript -> KeyPathInformation`: already exists.