### PR TITLE
Save TxOut in the Outpoint index

### DIFF
--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -1852,8 +1852,8 @@ namespace NBXplorer.Tests
 				async Task AssertMigration()
 				{
 					var repo = tester.GetService<RepositoryProvider>().GetRepository("BTC");
-					var actual = await repo.GetOutPointToScript(new List<OutPoint>(expected.Keys));
-					Assert.Equal(expected, actual);
+					var actual = await repo.GetOutPointToTxOut(new List<OutPoint>(expected.Keys));
+					Assert.Equal(expected, actual.ToDictionary(a => a.Key, a => a.Value.ScriptPubKey));
 				}
 				await AssertMigration();
 				tester.ResetExplorer(false);
@@ -1874,8 +1874,8 @@ namespace NBXplorer.Tests
 				async Task AssertMigration()
 				{
 					var repo = tester.GetService<RepositoryProvider>().GetRepository("BTC");
-					var actual = await repo.GetOutPointToScript(new List<OutPoint>(expected.Keys));
-					Assert.Equal(expected, actual);
+					var actual = await repo.GetOutPointToTxOut(new List<OutPoint>(expected.Keys));
+					Assert.Equal(expected, actual.ToDictionary(a => a.Key, a => a.Value.ScriptPubKey));
 				}
 				await AssertMigration();
 				tester.ResetExplorer(false);


### PR DESCRIPTION
We don't striclty need it, but given the cost (8 bytes) and the potential upside (signing with taproot requires having the previous amount), I think we should save it.

I also remove the call to `ToBytes` which is zipping the data. Since the data is mainly random, zipping/unzipping doesn't really save space while wasting CPU.

@sageprogrammer 