### PR TITLE
Add taproot derivation scheme

### DIFF
--- a/NBXplorer.Client/DerivationStrategy/TaprootDerivationStrategy.cs
+++ b/NBXplorer.Client/DerivationStrategy/TaprootDerivationStrategy.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using NBitcoin;
+using NBitcoin.Crypto;
+
+namespace NBXplorer.DerivationStrategy
+{
+	public class TaprootDerivationStrategy : DerivationStrategyBase
+	{
+		BitcoinExtPubKey _Root;
+
+		public ExtPubKey Root
+		{
+			get
+			{
+				return _Root;
+			}
+		}
+
+		protected internal override string StringValueCore
+		{
+			get
+			{
+				StringBuilder builder = new StringBuilder();
+				builder.Append(_Root.ToString());
+				builder.Append("-[taproot]");
+				return builder.ToString();
+			}
+		}
+
+		public TaprootDerivationStrategy(BitcoinExtPubKey root, ReadOnlyDictionary<string, bool> additionalOptions = null) : base(additionalOptions)
+		{
+			if (root == null)
+				throw new ArgumentNullException(nameof(root));
+			_Root = root;
+		}
+		public override Derivation GetDerivation()
+		{
+			var pubKey = _Root.ExtPubKey.PubKey.GetTaprootFullPubKey();
+			return new Derivation() { ScriptPubKey = pubKey.ScriptPubKey };
+		}
+
+		public override DerivationStrategyBase GetChild(KeyPath keyPath)
+		{
+			return new TaprootDerivationStrategy(_Root.ExtPubKey.Derive(keyPath).GetWif(_Root.Network), AdditionalOptions);
+		}
+
+		public override IEnumerable<ExtPubKey> GetExtPubKeys()
+		{
+			yield return _Root.ExtPubKey;
+		}
+	}
+}

--- a/NBXplorer.Client/JsonConverters/ScriptPubKeyTypeConverter.cs
+++ b/NBXplorer.Client/JsonConverters/ScriptPubKeyTypeConverter.cs
@@ -16,7 +16,8 @@ namespace NBXplorer.JsonConverters
 			{
 				{ "Legacy", ScriptPubKeyType.Legacy },
 				{ "Segwit", ScriptPubKeyType.Segwit },
-				{ "SegwitP2SH", ScriptPubKeyType.SegwitP2SH }
+				{ "SegwitP2SH", ScriptPubKeyType.SegwitP2SH },
+				{ "Taproot", ScriptPubKeyType.TaprootBIP86 }
 			};
 			_ScriptPubKeyTypeReverse = _ScriptPubKeyType.ToDictionary(kv => kv.Value, kv => kv.Key);
 		}

--- a/NBXplorer.Client/NBXplorer.Client.csproj
+++ b/NBXplorer.Client/NBXplorer.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<Company>Digital Garage</Company>
 		<Version>4.0.3</Version>
 		<Copyright>Copyright © Digital Garage 2017</Copyright>

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,12 +98,15 @@ Here a documentation of the different derivation scheme supported:
 | Multi-sig P2WSH | 2-of-xpub1-xpub2 |
 | Multi-sig P2SH-P2WSH | 2-of-xpub1-xpub2-[p2sh] |
 | Multi-sig P2SH | 2-of-xpub1-xpub2-[legacy] |
+| Taproot | xpub1-[taproot] |
 
 For multisig, the public keys are ordered before generating the address by default for privacy reason, use `-[keeporder]` to disable it.
 
 You can use more than one options at same time, example: `2-of-xpub1-xpub2-[legacy]-[keeporder]`
 
 Most of routes asks for a `cryptoCode`. This identify the crypto currency to request data from. (eg. `BTC`, `LTC`...)
+
+Note: Taproot is incompatible with all other options.
 
 ## <a name="track"></a>Track a derivation scheme
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,7 +98,7 @@ Here a documentation of the different derivation scheme supported:
 | Multi-sig P2WSH | 2-of-xpub1-xpub2 |
 | Multi-sig P2SH-P2WSH | 2-of-xpub1-xpub2-[p2sh] |
 | Multi-sig P2SH | 2-of-xpub1-xpub2-[legacy] |
-| Taproot | xpub1-[taproot] |
+| P2TR | xpub1-[taproot] |
 
 For multisig, the public keys are ordered before generating the address by default for privacy reason, use `-[keeporder]` to disable it.
 


### PR DESCRIPTION
This PR includes:

- Derivation scheme for Taproot.
- Modified the corresponding tests.
- Changed client target framework from `netstandard2.0` to `netstandard2.1` 