### PR TITLE
Change min rpc version for GRS

### DIFF
--- a/NBXplorer.Client/NBXplorerNetworkProvider.Groestlcoin.cs
+++ b/NBXplorer.Client/NBXplorerNetworkProvider.Groestlcoin.cs
@@ -11,7 +11,7 @@ namespace NBXplorer
 		{
 			Add(new NBXplorerNetwork(NBitcoin.Altcoins.Groestlcoin.Instance, networkType)
 			{
-				MinRPCVersion = 2160000,
+				MinRPCVersion = 150000,
 				CoinType = NetworkType == ChainName.Mainnet ? new KeyPath("17'") : new KeyPath("1'")
 			});
 		}


### PR DESCRIPTION
This is needed as the upcoming GRS version (v22.0.0) has `MinRPCVersion = 220000,`