### PR TITLE
NBXplorer create default RPC wallet when possible

### DIFF
--- a/NBXplorer.Client/NBXplorer.Client.csproj
+++ b/NBXplorer.Client/NBXplorer.Client.csproj
@@ -27,7 +27,7 @@
 		<Optimize>true</Optimize>
         </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="NBitcoin" Version="7.0.21" />
+		<PackageReference Include="NBitcoin" Version="7.0.22" />
 		<PackageReference Include="NBitcoin.Altcoins" Version="3.0.17" />
 		<PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
 	</ItemGroup>

--- a/NBXplorer.Tests/NBXplorer.Tests.csproj
+++ b/NBXplorer.Tests/NBXplorer.Tests.csproj
@@ -11,7 +11,7 @@
     <EmbeddedResource Include="Scripts\generate-whale.sql" />
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="NBitcoin.TestFramework" Version="3.0.17" />
+      <PackageReference Include="NBitcoin.TestFramework" Version="3.0.19" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 	  <PackageReference Include="xunit" Version="2.4.2" />
 	  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/NBXplorer.Tests/ServerTester.Environment.cs
+++ b/NBXplorer.Tests/ServerTester.Environment.cs
@@ -10,6 +10,8 @@ namespace NBXplorer.Tests
     {
 		NBXplorerNetworkProvider _Provider = new NBXplorerNetworkProvider(ChainName.Regtest);
 
+		public bool CreateWallet { get; set; } = false;
+
 		private void SetEnvironment()
 		{
 			//CryptoCode = "AGM";

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -1656,7 +1656,7 @@ namespace NBXplorer.Tests
 				Logs.Tester.LogInformation($"Funding tx ({fundingTxId}) has two coins");
 				Logs.Tester.LogInformation("Let's spend one of the coins");
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/1"));
+				tester.ImportPrivKey(key, "0/1");
 
 				var spending1 = tester.RPC.SendToAddress(new Key().PubKey.Hash.GetAddress(tester.Network), Money.Coins(0.1m));
 				tester.Notifications.WaitForTransaction(pubkey, spending1);
@@ -1673,7 +1673,7 @@ namespace NBXplorer.Tests
 
 				Logs.Tester.LogInformation("Let's spend the other coin");
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/0"));
+				tester.ImportPrivKey(key, "0/0");
 				var unspentt = tester.RPC.ListUnspent();
 				var spending2 = tester.RPC.SendToAddress(new Key().PubKey.Hash.GetAddress(tester.Network), Money.Coins(0.1m));
 				tester.Notifications.WaitForTransaction(pubkey, spending2);
@@ -1770,14 +1770,14 @@ namespace NBXplorer.Tests
 				// Let's spend one of the coins of funding and spend it again
 				// [funding, spending1, spending2]
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/1"));
+				tester.ImportPrivKey(key, "0/1");
 				var coinDestination = tester.Client.GetUnused(pubkey, DerivationFeature.Deposit);
 				var coinDestinationAddress = coinDestination.ScriptPubKey;
 				var spending1 = tester.RPC.SendToAddress(coinDestinationAddress, Money.Coins(0.1m));
 				Logs.Tester.LogInformation($"Spent the coin to 0/1 in spending1({spending1})");
 				tester.Notifications.WaitForTransaction(pubkey, spending1);
 				LockTestCoins(tester.RPC, new HashSet<Script>());
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, coinDestination.KeyPath.ToString()));
+				tester.ImportPrivKey(key, coinDestination.KeyPath.ToString());
 				var spending2 = tester.RPC.SendToAddress(new Key().GetScriptPubKey(ScriptPubKeyType.Legacy), Money.Coins(0.01m));
 				tester.Notifications.WaitForTransaction(pubkey, spending2);
 				Logs.Tester.LogInformation($"Spent again the coin in spending2({spending2})");
@@ -1797,7 +1797,7 @@ namespace NBXplorer.Tests
 				// Let's spend the other coin of fundingTx
 				Thread.Sleep(1000);
 				LockTestCoins(tester.RPC, new HashSet<Script>());
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/0"));
+				tester.ImportPrivKey(key, "0/0");
 				var spending3 = tester.RPC.SendToAddress(new Key().PubKey.Hash.GetAddress(tester.Network), Money.Coins(0.1m));
 				tester.Notifications.WaitForTransaction(pubkey, spending3);
 				Logs.Tester.LogInformation($"Spent the second coin to 0/0 in spending3({spending3})");
@@ -2155,7 +2155,7 @@ namespace NBXplorer.Tests
 
 				Logs.Tester.LogInformation("Let's send 0.6BTC from alice 0/1 to bob 0/3");
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(alice, "0/1"));
+				tester.ImportPrivKey(alice, "0/1");
 				id = tester.SendToAddress(tester.AddressOf(bob, "0/3"), Money.Coins(0.6m));
 				tester.Notifications.WaitForTransaction(bobPubKey, id);
 
@@ -2240,7 +2240,7 @@ namespace NBXplorer.Tests
 				tester.Client.Track(pubkey);
 
 				var addresses = new HashSet<Script>();
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/0"));
+				tester.ImportPrivKey(key, "0/0");
 				var id = tester.SendToAddress(tester.AddressOf(key, "0/0"), Money.Coins(1.0m));
 				tester.Notifications.WaitForTransaction(pubkey, id);
 				addresses.Add(tester.AddressOf(key, "0/0").ScriptPubKey);
@@ -2264,7 +2264,7 @@ namespace NBXplorer.Tests
 					coins = coins - Money.Coins(0.001m);
 					var path = $"0/{i + 1}";
 					var destination = tester.AddressOf(key, path);
-					tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, path));
+					tester.ImportPrivKey(key, path);
 					var txId = tester.SendToAddress(destination, coins);
 					Logs.Tester.LogInformation($"Sent to {path} in {txId}");
 					addresses.Add(destination.ScriptPubKey);
@@ -2460,7 +2460,7 @@ namespace NBXplorer.Tests
 				utxo = tester.Client.GetUTXOs(addressSource);
 				var utxo2 = tester.Client.GetUTXOs(pubkey2);
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(extkey2, "0/0"));
+				tester.ImportPrivKey(extkey2, "0/0");
 				var tx2 = tester.SendToAddress(address, Money.Coins(0.6m));
 				tester.Notifications.WaitForTransaction(address, tx2);
 				tester.RPC.EnsureGenerate(1);
@@ -2497,7 +2497,7 @@ namespace NBXplorer.Tests
 
 				Logs.Tester.LogInformation("Let's send 0.6BTC from 0/0 to 1/0");
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/0"));
+				tester.ImportPrivKey(key, "0/0");
 				var tx2 = tester.SendToAddress(tester.AddressOf(key, "1/0"), Money.Coins(0.6m));
 				tester.Notifications.WaitForTransaction(pubkey, tx2);
 
@@ -2704,7 +2704,7 @@ namespace NBXplorer.Tests
 
 				Logs.Tester.LogInformation("Let's send from 0/0 to 0/1");
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/0"));
+				tester.ImportPrivKey(key, "0/0");
 				var txId3 = tester.SendToAddress(tester.AddressOf(key, "0/1"), Money.Coins(0.2m));
 				tester.Notifications.WaitForTransaction(pubkey, txId3);
 				result = tester.Client.GetTransactions(pubkey);
@@ -2735,7 +2735,7 @@ namespace NBXplorer.Tests
 
 				Logs.Tester.LogInformation("Send 0.2BTC from the 0/0 to a random address");
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/0"));
+				tester.ImportPrivKey(key, "0/0");
 				var spendingTx = tester.SendToAddress(new Key().PubKey.Hash.GetAddress(tester.Network), Money.Coins(0.2m));
 				tester.Notifications.WaitForTransaction(pubkey, spendingTx);
 				Logs.Tester.LogInformation("Check we have empty UTXO as unconfirmed");
@@ -2971,7 +2971,7 @@ namespace NBXplorer.Tests
 
 				Logs.Tester.LogInformation("Let's send 0.5 BTC from 0/1 to 0/3");
 				LockTestCoins(tester.RPC);
-				tester.RPC.ImportPrivKey(tester.PrivateKeyOf(key, "0/1"));
+				tester.ImportPrivKey(key, "0/1");
 				txId = tester.SendToAddress(tester.AddressOf(key, "0/3"), Money.Coins(0.5m));
 				tester.Notifications.WaitForTransaction(pubkey, txId);
 
@@ -3996,6 +3996,7 @@ namespace NBXplorer.Tests
 		{
 			using (var tester = ServerTester.CreateNoAutoStart(backend))
 			{
+				tester.CreateWallet = true;
 				tester.RPCWalletType = walletType;
 				tester.Start();
 				var cashNode = tester.NodeBuilder.CreateNode(true);

--- a/NBXplorer/Configuration/DefaultConfiguration.cs
+++ b/NBXplorer/Configuration/DefaultConfiguration.cs
@@ -39,6 +39,7 @@ namespace NBXplorer.Configuration
 				app.Option($"--{crypto}rescan", $"Rescan from startheight", CommandOptionType.BoolValue);
 				app.Option($"--{crypto}rescaniftimebefore", $"Only perform rescan if before timestamp (UTC unix timestamp in seconds) (requires --{crypto}rescan)", CommandOptionType.SingleValue);
 				app.Option($"--{crypto}rpcuser", $"RPC authentication method 1: The RPC user (default: using cookie auth from default network folder)", CommandOptionType.SingleValue);
+				app.Option($"--{crypto}rpcdefaultwallet", $"The default RPC wallet used by NBXplorer. RPC wallet features aren't strictly needed, only for NBXplorer wallet created with `importKeysToRPC` (default: empty name)", CommandOptionType.SingleValue);
 				app.Option($"--{crypto}rpcpassword", $"RPC authentication method 1: The RPC password (default: using cookie auth from default network folder)", CommandOptionType.SingleValue);
 				app.Option($"--{crypto}rpccookiefile", $"RPC authentication method 2: The RPC cookiefile (default: using cookie auth from default network folder)", CommandOptionType.SingleValue);
 				app.Option($"--{crypto}rpcauth", $"RPC authentication method 3: user:password or cookiefile=path (default: using cookie auth from default network folder)", CommandOptionType.SingleValue);

--- a/NBXplorer/Configuration/RPCArgs.cs
+++ b/NBXplorer/Configuration/RPCArgs.cs
@@ -32,6 +32,7 @@ namespace NBXplorer.Configuration
 		{
 			get; set;
 		}
+		public string DefaultWallet { get; set; }
 		public bool NoTest
 		{
 			get;
@@ -85,6 +86,8 @@ namespace NBXplorer.Configuration
 					}
 				}
 			}
+			if (DefaultWallet is not null)
+				rpcClient = rpcClient.GetWallet(DefaultWallet);
 			return rpcClient;
 		}
 
@@ -182,6 +185,7 @@ namespace NBXplorer.Configuration
 				{
 					User = confArgs.GetOrDefault<string>(prefix + "rpc.user", null),
 					Password = confArgs.GetOrDefault<string>(prefix + "rpc.password", null),
+					DefaultWallet = confArgs.GetOrDefault<string>(prefix + "rpc.defaultwallet", null),
 					CookieFile = confArgs.GetOrDefault<string>(prefix + "rpc.cookiefile", null),
 					AuthenticationString = confArgs.GetOrDefault<string>(prefix + "rpc.auth", null),
 					Url = url == null ? null : new Uri(url)


### PR DESCRIPTION
A user ended up in a situation where his install was bricked.

The previous RPC wallet for some reason got corrupted, he then proceed to remove it.
When restarting our btcpayserver's bitcoin core container, it tries to recreate a new wallet with `bitcoin-wallet`.

However, the newly created wallet prevent Bitcoin Core to start because Bitcoin Core thinks it needs to scan the blockchain, when all our users are pruned.

This should be fixed in https://github.com/bitcoin/bitcoin/pull/26679.
However, creating with the API instead will allow bitcoin core to properly set the `bestblock` of the wallet, so it won't require a rescan.

Note that we are creating a descriptor wallet.

I added a new option `NBXPLORER_BTCRPCDEFAULTWALLET` which allow you to configure what will be the name of the default wallet. This is empty by default.