### PR TITLE
tracked_txs shouldn't return transaction not in mempool and not confirmed

### DIFF
--- a/NBXplorer/DBScripts/013.FixTrackedTransactions.sql
+++ b/NBXplorer/DBScripts/013.FixTrackedTransactions.sql
@@ -1,0 +1,25 @@
+﻿CREATE OR REPLACE VIEW nbxv1_tracked_txs AS
+ SELECT ws.wallet_id,
+    io.code,
+    io.tx_id,
+    io.idx,
+    io.is_out,
+    io.spent_tx_id,
+    io.spent_idx,
+    io.script,
+    io.value,
+    io.asset_id,
+    io.immature,
+    io.blk_id,
+    io.blk_idx,
+    io.blk_height,
+    io.mempool,
+    io.replaced_by,
+    io.seen_at,
+    nbxv1_get_keypath(d.metadata, ds.idx) AS keypath
+   FROM ((wallets_scripts ws
+     JOIN ins_outs io ON (((io.code = ws.code) AND (io.script = ws.script))))
+     LEFT JOIN ((wallets_descriptors wd
+     JOIN descriptors_scripts ds ON (((ds.code = wd.code) AND (ds.descriptor = wd.descriptor))))
+     JOIN descriptors d ON (((d.code = ds.code) AND (d.descriptor = ds.descriptor)))) ON (((wd.wallet_id = ws.wallet_id) AND (wd.code = ws.code) AND (ds.script = ws.script))))
+    WHERE io.blk_id IS NOT NULL OR io.mempool IS TRUE;

--- a/NBXplorer/DBScripts/FullSchema.sql
+++ b/NBXplorer/DBScripts/FullSchema.sql
@@ -973,7 +973,8 @@ CREATE VIEW nbxv1_tracked_txs AS
      JOIN ins_outs io ON (((io.code = ws.code) AND (io.script = ws.script))))
      LEFT JOIN ((wallets_descriptors wd
      JOIN descriptors_scripts ds ON (((ds.code = wd.code) AND (ds.descriptor = wd.descriptor))))
-     JOIN descriptors d ON (((d.code = ds.code) AND (d.descriptor = ds.descriptor)))) ON (((wd.wallet_id = ws.wallet_id) AND (wd.code = ws.code) AND (ds.script = ws.script))));
+     JOIN descriptors d ON (((d.code = ds.code) AND (d.descriptor = ds.descriptor)))) ON (((wd.wallet_id = ws.wallet_id) AND (wd.code = ws.code) AND (ds.script = ws.script))))
+  WHERE ((io.blk_id IS NOT NULL) OR (io.mempool IS TRUE));
 
 CREATE TABLE outs (
     code text NOT NULL,
@@ -1325,6 +1326,7 @@ INSERT INTO nbxv1_migrations VALUES ('009.FasterGetUnused2');
 INSERT INTO nbxv1_migrations VALUES ('010.ChangeEventsIdType');
 INSERT INTO nbxv1_migrations VALUES ('011.FixGetWalletsRecent');
 INSERT INTO nbxv1_migrations VALUES ('012.PerfFixGetWalletsRecent');
+INSERT INTO nbxv1_migrations VALUES ('013.FixTrackedTransactions');
 
 ALTER TABLE ONLY nbxv1_migrations
     ADD CONSTRAINT nbxv1_migrations_pkey PRIMARY KEY (script_name);

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -19,6 +19,7 @@
     <None Remove="DBScripts\010.ChangeEventsIdType.sql" />
     <None Remove="DBScripts\011.FixGetWalletsRecent.sql" />
     <None Remove="DBScripts\012.PerfFixGetWalletsRecent.sql" />
+    <None Remove="DBScripts\013.FixTrackedTransactions.sql" />
   </ItemGroup>
   <ItemGroup>
 	<EmbeddedResource Include="DBScripts\*.sql" />


### PR DESCRIPTION
Transactions which aren't in the mempool and not confirmed (ie, completely replaced) shouldn't appear anymore in the `tracked_txs` output.

This caused `/transactions` to include transactions which were unconfirmed while they were completely replaced.