### PR TITLE
Fix: Wallets migrated from DBTrie might reuse addresses

### DIFF
--- a/NBXplorer.Tests/DatabaseTests.cs
+++ b/NBXplorer.Tests/DatabaseTests.cs
@@ -13,13 +13,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
 using Xunit.Abstractions;
 using Microsoft.Extensions.Configuration;
-using NBXplorer.Configuration;
 using System.Runtime.CompilerServices;
 using System.IO;
 using System.Diagnostics;
-using System.Globalization;
-using NBitcoin.DataEncoders;
-using NBitcoin.Crypto;
 using NBXplorer.Backends.Postgres;
 using NBXplorer.Client;
 

--- a/NBXplorer/Backends/Postgres/PostgresRepository.cs
+++ b/NBXplorer/Backends/Postgres/PostgresRepository.cs
@@ -889,7 +889,7 @@ namespace NBXplorer.Backends.Postgres
 						ki.ScriptPubKey.ToHex(),
 						metadata?.ToString(Formatting.None),
 						addr.ToString(),
-						true));
+						false));
 				}
 				else
 				{
@@ -908,7 +908,7 @@ namespace NBXplorer.Backends.Postgres
 
 			if (inserts.Count > 0)
 				await connection.ExecuteAsync(
-					"INSERT INTO scripts VALUES (@code, @script, @address, 't') ON CONFLICT DO NOTHING;" +
+					"INSERT INTO scripts VALUES (@code, @script, @address) ON CONFLICT DO NOTHING;" +
 					"INSERT INTO wallets_scripts VALUES (@code, @script, @walletid) ON CONFLICT DO NOTHING;", inserts);
 		}
 

--- a/NBXplorer/DBScripts/014.FixAddressReuse.sql
+++ b/NBXplorer/DBScripts/014.FixAddressReuse.sql
@@ -1,0 +1,65 @@
+﻿CREATE OR REPLACE FUNCTION scripts_set_descriptors_scripts_used() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF NEW.used != OLD.used AND NEW.used IS TRUE THEN
+    UPDATE descriptors_scripts ds SET used='t' WHERE code=NEW.code AND script=NEW.script AND used='f';
+  END IF;
+  RETURN NEW;
+END $$;
+
+
+CREATE OR REPLACE FUNCTION outs_denormalize_to_ins_outs() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  r RECORD;
+BEGIN
+  INSERT INTO ins_outs
+  SELECT
+	o.code,
+	o.tx_id,
+	o.idx,
+	't',
+	NULL,
+	NULL,
+	o.script,
+	o.value,
+	o.asset_id,
+	o.immature,
+	t.blk_id,
+	t.blk_idx,
+	t.blk_height,
+	t.mempool,
+	t.replaced_by,
+	t.seen_at
+	FROM new_outs o
+	JOIN txs t ON t.code=o.code AND t.tx_id=o.tx_id;
+	-- Mark scripts as used
+	FOR r IN SELECT * FROM new_outs
+	LOOP
+	  UPDATE scripts
+		SET used='t'
+		WHERE code=r.code AND script=r.script AND used IS FALSE;
+	END LOOP;
+	RETURN NULL;
+END
+$$;
+
+
+-- Select all scripts that are used but without outs
+-- Fix them to used='f'
+-- This could happen because of bug during migration from DBTrie
+UPDATE scripts s
+SET used='f'
+FROM (SELECT s.code, s.script FROM scripts s
+LEFT JOIN outs o USING (code, script)
+WHERE used='t' AND o.script is NULL) s2
+WHERE s2.code=s.code AND s2.script=s.script AND s.used='t';
+
+
+-- Make sure that all the descriptors_scripts which aren't used, but with scripts used are fixed to used
+UPDATE descriptors_scripts ds
+SET used='t'
+FROM scripts s
+WHERE s.code=ds.code AND s.script=ds.script AND ds.used='f' AND s.used = 't';

--- a/NBXplorer/DBScripts/FullSchema.sql
+++ b/NBXplorer/DBScripts/FullSchema.sql
@@ -535,7 +535,7 @@ BEGIN
 	LOOP
 	  UPDATE scripts
 		SET used='t'
-		WHERE code=r.code AND script=r.script;
+		WHERE code=r.code AND script=r.script AND used IS FALSE;
 	END LOOP;
 	RETURN NULL;
 END
@@ -605,7 +605,7 @@ CREATE FUNCTION scripts_set_descriptors_scripts_used() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-  IF NEW.used != OLD.used THEN
+  IF NEW.used != OLD.used AND NEW.used IS TRUE THEN
     UPDATE descriptors_scripts ds SET used='t' WHERE code=NEW.code AND script=NEW.script AND used='f';
   END IF;
   RETURN NEW;
@@ -1327,6 +1327,7 @@ INSERT INTO nbxv1_migrations VALUES ('010.ChangeEventsIdType');
 INSERT INTO nbxv1_migrations VALUES ('011.FixGetWalletsRecent');
 INSERT INTO nbxv1_migrations VALUES ('012.PerfFixGetWalletsRecent');
 INSERT INTO nbxv1_migrations VALUES ('013.FixTrackedTransactions');
+INSERT INTO nbxv1_migrations VALUES ('014.FixAddressReuse');
 
 ALTER TABLE ONLY nbxv1_migrations
     ADD CONSTRAINT nbxv1_migrations_pkey PRIMARY KEY (script_name);

--- a/NBXplorer/HostedServices/DBTrieToPostgresMigratorHostedService.cs
+++ b/NBXplorer/HostedServices/DBTrieToPostgresMigratorHostedService.cs
@@ -339,6 +339,7 @@ namespace NBXplorer.HostedServices
 					await CreateWalletAndDescriptor(conn, walletKeys, descriptors);
 					await postgresRepo.SaveKeyInformations(conn, batch.ToArray());
 
+					await conn.ExecuteAsync("UPDATE descriptors_scripts SET used='t'");
 					await conn.ExecuteAsync(
 									"ALTER TABLE descriptors_scripts " +
 									"ENABLE TRIGGER USER;");

--- a/NBXplorer/HostedServices/DatabaseSetupHostedService.cs
+++ b/NBXplorer/HostedServices/DatabaseSetupHostedService.cs
@@ -32,8 +32,8 @@ namespace NBXplorer.HostedServices
 			{
 				await using var conn = await ConnectionFactory.CreateConnection(b =>
 				{
-					b.Timeout = 120;
-					b.CommandTimeout = 120;
+					// 10H timeout
+					b.CommandTimeout = 60 * 60 * 10;
 				});
 				await RunScripts(conn);
 			}

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -20,6 +20,7 @@
     <None Remove="DBScripts\011.FixGetWalletsRecent.sql" />
     <None Remove="DBScripts\012.PerfFixGetWalletsRecent.sql" />
     <None Remove="DBScripts\013.FixTrackedTransactions.sql" />
+    <None Remove="DBScripts\014.FixAddressReuse.sql" />
   </ItemGroup>
   <ItemGroup>
 	<EmbeddedResource Include="DBScripts\*.sql" />


### PR DESCRIPTION
This is a bug that nobody saw until now and that has been present for a long time.

Old NBXplorer installs migrated from DBTrie had a bug that would result in some wallet reusing addresses indifinitely.
More generally, the call to get unused address would return already used addresses.

In BTCPay it would result in change address reuse, which is very bad for privacy.