### PR TITLE
Allow SOCKSv5 configuration for P2P connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,10 @@
 version: 2
 jobs:
   test:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      - image: ubuntu-2004:202201-02
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.7
       - run:
           command: |
             cd .circleci && ./run-tests.sh

--- a/NBXplorer/Configuration/DefaultConfiguration.cs
+++ b/NBXplorer/Configuration/DefaultConfiguration.cs
@@ -86,6 +86,9 @@ namespace NBXplorer.Configuration
 			app.Option("--nomigrateevts", $"Do not migrate the events table (default: false)", CommandOptionType.BoolValue);
 			app.Option("--nomigraterawtxs", $"Do not migrate the raw bytes of transactions (default: false)", CommandOptionType.BoolValue);
 #endif
+			app.Option("--socksendpoint", "Configure a SocksV5 endpoint as proxy to connect to P2P", CommandOptionType.SingleValue);
+			app.Option("--socksuser", "SocksV5 username credential", CommandOptionType.SingleValue);
+			app.Option("--sockspassword", "SocksV5 password credential", CommandOptionType.SingleValue);
 			app.Option("-v | --verbose", $"Verbose logs (default: true)", CommandOptionType.SingleValue);
 			return app;
 		}

--- a/NBXplorer/Configuration/ExplorerConfiguration.cs
+++ b/NBXplorer/Configuration/ExplorerConfiguration.cs
@@ -171,6 +171,18 @@ namespace NBXplorer.Configuration
 			var invalidChains = String.Join(',', supportedChains.Where(s => !validChains.Contains(s)).ToArray());
 			if(!string.IsNullOrEmpty(invalidChains))
 				throw new ConfigException($"Invalid chains {invalidChains} for {NetworkProvider.NetworkType}");
+			SocksEndpoint = config.GetOrDefault<string>($"socks.endpoint", null) is string e ? NBitcoin.Utils.ParseEndpoint(e, 1080) : null;
+			if (SocksEndpoint != null)
+			{
+				Logs.Configuration.LogInformation("Socks endpoint: " + SocksEndpoint.ToEndpointString());
+				var user = config.GetOrDefault<string>("socks.user", null);
+				var pass = config.GetOrDefault<string>("socks.password", null);
+				if (user != null && pass != null)
+				{
+					Logs.Configuration.LogInformation("Socks credentials detected");
+					SocksCredentials = new NetworkCredential(user, pass);
+				}
+			}
 
 			Logs.Configuration.LogInformation("Supported chains: " + String.Join(',', supportedChains.ToArray()));
 			MinGapSize = config.GetOrDefault<int>("mingapsize", 20);
@@ -312,5 +324,7 @@ namespace NBXplorer.Configuration
         public string RabbitMqBlockExchange { get; set; }
 
 		public KeyPathTemplate CustomKeyPathTemplate { get; set; }
+		public EndPoint SocksEndpoint { get; set; }
+		public NetworkCredential SocksCredentials { get; set; }
 	}
 }


### PR DESCRIPTION
Can use `NBXPLORER_SOCKS_ENDPOINT`, `NBXPLORER_SOCKS_USER`, `NBXPLORER_SOCKS_PASSWORD` to configure a SocksV5 proxy to connect to the P2P network.