### PR TITLE
Allow creation of PSBTs conflicting with mempool with includeOnlyOutpoints

### DIFF
--- a/NBXplorer.Client/Models/CreatePSBTRequest.cs
+++ b/NBXplorer.Client/Models/CreatePSBTRequest.cs
@@ -64,6 +64,11 @@ namespace NBXplorer.Models
 		public List<OutPoint> IncludeOnlyOutpoints { get; set; }
 
 		/// <summary>
+		/// If `true`, all the UTXOs that have been selected will be used as input in the PSBT. (default to false)
+		/// </summary>
+		public bool? SpendAllMatchingOutpoints { get; set; }
+
+		/// <summary>
 		/// Use a specific change address (Optional, default: null, mutually exclusive with ReserveChangeAddress)
 		/// </summary>
 		public BitcoinAddress ExplicitChangeAddress { get; set; }

--- a/NBXplorer.Client/Models/UTXOChanges.cs
+++ b/NBXplorer.Client/Models/UTXOChanges.cs
@@ -42,6 +42,11 @@ namespace NBXplorer.Models
 			}
 		}
 
+		public List<UTXO> SpentUnconfirmed
+		{
+			get;
+			set;
+		} = new List<UTXO>();
 
 		UTXOChange _Confirmed = new UTXOChange();
 		public UTXOChange Confirmed

--- a/NBXplorer/Controllers/PostgresMainController.cs
+++ b/NBXplorer/Controllers/PostgresMainController.cs
@@ -187,11 +187,15 @@ namespace NBXplorer.Controllers
 				}
 				u.Address = utxo.address is null ? u.ScriptPubKey.GetDestinationAddress(network.NBitcoinNetwork) : BitcoinAddress.Create(utxo.address, network.NBitcoinNetwork);
 				if (!utxo.mempool)
+				{
 					changes.Confirmed.UTXOs.Add(u);
+					if (utxo.input_mempool)
+						changes.Unconfirmed.SpentOutpoints.Add(u.Outpoint);
+				}
 				else if (!utxo.input_mempool)
 					changes.Unconfirmed.UTXOs.Add(u);
-				if (utxo.input_mempool && !utxo.mempool)
-					changes.Unconfirmed.SpentOutpoints.Add(u.Outpoint);
+				else // (utxo.mempool && utxo.input_mempool)
+					changes.SpentUnconfirmed.Add(u);
 			}
 			return Json(changes, network.JsonSerializerSettings);
 		}

--- a/NBXplorer/Logging/LogAllRequestsMiddleware.cs
+++ b/NBXplorer/Logging/LogAllRequestsMiddleware.cs
@@ -21,6 +21,11 @@ namespace NBXplorer.Logging
 
 		public async Task Invoke(HttpContext context)
 		{
+			if (context.Request.ContentType == "application/octet-stream")
+			{
+				await _next(context);
+				return;
+			}
 			//First, get the incoming request
 			var request = await FormatRequest(context.Request);
 			Logs.Explorer.LogInformation(request);

--- a/docs/API.md
+++ b/docs/API.md
@@ -555,11 +555,32 @@ Result:
     "spentOutpoints": [
       "9345f9585d643a31202e686ec7a4c2fe17917a5e7731a79d2327d24d25c0339f01000000"
     ],
+    "spentUnconfirmed": [
+    {
+      "feature": "Deposit",
+      "outpoint": "c8fd6675624d0b88056b9eaf945c5fd0c4614f7ddf44eb81911b3a66ba0e57a001000000",
+      "index": 1,
+      "transactionHash": "a0570eba663a1b9181eb44df7d4f61c4d05f5c94af9e6b05880b4d627566fdc8",
+      "scriptPubKey": "0014d77089591a85fa3a91e14f587c50e4b777ffd833",
+      "address": "bcrt1q6acgjkg6shar4y0pfav8c58ykamllkpnz6rnxh",
+      "value": 100000,
+      "keyPath": "0/0",
+      "timestamp": 1699930040,
+      "confirmations": 0
+    }
+    ],
     "hasChanges": true
   },
   "hasChanges": true
 }
 ```
+
+Response:
+* `confirmed.utxOs`: UTXOs that are confirmed. (UTXO spent by an unconfirmed transaction are also included)
+* `unconfirmed.spentOutpoints`: Always empty.
+* `unconfirmed.utxOs`: UTXOs that will be confirmed once the unconfirmed transactions are confirmed.
+* `unconfirmed.spentOutpoints`: Confirmed UTXOs that will spent once the transactions are confirmed.
+* `spentUnconfirmed`: UTXOs that are spent by an unconfirmed transaction.
 
 This call does not returns conflicted unconfirmed UTXOs.
 Note that confirmed utxo, do not include immature UTXOs. (ie. UTXOs belonging to a coinbase transaction with less than 100 confirmations)
@@ -1010,6 +1031,7 @@ Fields:
   },
   "discourageFeeSniping": true,
   "reserveChangeAddress": false,
+  "spendAllMatchingOutpoints": false,
   "minConfirmations": 0,
   "excludeOutpoints": [
     "7c02d7d6923ab5e9bbdadf7cf6873a5454ae5aa86d15308ed8d68840a79cf644-1",
@@ -1035,9 +1057,10 @@ Fields:
 * `includeGlobalXPub`: Optional. Whether or not to include the global xpubs of the derivation scheme in the PSBT. (default: false)
 * `rbf`: Optional, determine if the transaction should have Replace By Fee (RBF) activated (default: `true`, if `disableFingerprintRandomization` is `true`)
 * `reserveChangeAddress`: default to false, whether the creation of this PSBT will reserve a new change address.
+* `spendAllMatchingOutpoints`: If `true`, all the UTXOs that have been selected will be used as input in the PSBT. (default to false)
 * `explicitChangeAddress`: default to null, use a specific change address (Optional, mutually exclusive with reserveChangeAddress)
 * `minConfirmations`: default to 0, the minimum confirmations a UTXO need to be selected. (by default unconfirmed and confirmed UTXO will be used)
-* `includeOnlyOutpoints`: Only select the following outpoints for creating the PSBT (default to null)
+* `includeOnlyOutpoints`: Only select the following outpoints for creating the PSBT. Note that it can also select outpoints that has been already spent, but where the spending is unconfirmed, so it can be used for RBF. (default to null)
 * `excludeOutpoints`: Do not select the following outpoints for creating the PSBT (default to empty)
 * `minValue`: UTXO's with value below this amount will be ignored (default to null)
 * `destinations`: Required, the destinations where to send the money


### PR DESCRIPTION
Fix https://github.com/dgarage/NBXplorer/issues/434

The proposed PR introduces new properties:

* `CreatePSBTRequest.spendAllMatchingOutpoints`: This ensures that all selected outpoints are spent, rather than just enough to cover the amount.
* `UTXOChanges.spentUnconfirmed`: This is a list of unconfirmed UTXOs that have been spent by another unconfirmed transaction.

Additionally, `CreatePSBTRequest.includeOnlyOutpoints` has been enhanced to select UTXOs that have been spent in the mempool, facilitating Replace-By-Fee (RBF). In other words, it can select any `UTXOChanges.spentUnconfirmed`, as well as any `UTXOChanges.Confirmed.UTXO`, regardless of their spent status.

Consider a scenario with three transactions: `A`, `B`, and `C` To reduce fees, you decide to consolidate them into a single transaction. You would select all their inputs using `CreatePSBTRequest.includeOnlyOutpoints` and set `spendAllMatchingOutpoints` to `true`, this would ensure that all of their inputs are included in the new transaction.

@Kukks @farukterzioglu 