### PR TITLE
Stop supporting DBTrie backend

### DIFF
--- a/NBXplorer.Tests/ServerTester.cs
+++ b/NBXplorer.Tests/ServerTester.cs
@@ -71,6 +71,8 @@ namespace NBXplorer.Tests
 			_Name = directory;
 			Backend = backend;
 			SetEnvironment();
+			if (backend == Backend.DBTrie)
+				Environment.SetEnvironmentVariable("NBXPLORER_ALLOW_DBTRIE", "1");
 			Caller = directory;
 			var rootTestData = "TestData";
 			directory = Path.Combine(rootTestData, directory);

--- a/NBXplorer/Configuration/DefaultConfiguration.cs
+++ b/NBXplorer/Configuration/DefaultConfiguration.cs
@@ -74,7 +74,7 @@ namespace NBXplorer.Configuration
 			app.Option("--exposerpc", $"Expose the node RPC through the REST API (default: false)", CommandOptionType.SingleValue);
 			app.Option("--postgres", $"Use PostgresSQL backend. Set the connection string of the postgres backend (For example: \"User ID=postgres;Host=postgres;Port=5432;Application Name=nbxplorer;Database=nbxplorer\", more options on https://www.npgsql.org/doc/connection-string-parameters.html)", CommandOptionType.SingleValue);
 #if SUPPORT_DBTRIE
-			app.Option("--dbtrie", $"Use DBTrie backend. This backend is deprecated, only use if you haven't yet migrated. For more information about how to migrate, see https://github.com/dgarage/NBXplorer/tree/master/docs/Postgres-Migration.md", CommandOptionType.BoolValue);
+			app.Option("--dbtrie", $"Not supported anymore. For more information about how to migrate, see https://github.com/dgarage/NBXplorer/tree/master/docs/Postgres-Migration.md", CommandOptionType.BoolValue);
 			app.Option("--automigrate", $"If legacy installation detected, migrate it to postgres (default: false)", CommandOptionType.BoolValue);
 			app.Option("--deleteaftermigration", $"If automigrate is used, and this flag is true, the old DBTrie database will be automatically deleted after migration (default: false)", CommandOptionType.BoolValue);
 			app.Option("--nomigrateevts", $"Do not migrate the events table (default: false)", CommandOptionType.BoolValue);

--- a/NBXplorer/Configuration/ExplorerConfiguration.cs
+++ b/NBXplorer/Configuration/ExplorerConfiguration.cs
@@ -229,9 +229,9 @@ namespace NBXplorer.Configuration
 					"  * To use postgres, please use --postgres \"...\" (or NBXPLORER_POSTGRES=\"...\") with a postgres connection string (see https://www.connectionstrings.com/postgresql/)" + Environment.NewLine +
 					"  * To use DBTrie, use --dbtrie (or NBXPLORER_DBTRIE=1). This backend is deprecated, only use if you haven't yet migrated. For more information about how to migrate, see https://github.com/dgarage/NBXplorer/tree/master/docs/Postgres-Migration.md");
 			}
-			if (IsDbTrie)
+			if (IsDbTrie && config["ALLOW_DBTRIE"] != "1")
 			{
-				Logs.Configuration.LogWarning("Warning: A DBTrie backend has been selected, but this backend is deprecated, only use if you haven't yet migrated to postgres. For more information about how to migrate, see https://github.com/dgarage/NBXplorer/tree/master/docs/Postgres-Migration.md");
+				throw new ConfigException("DBTrie backend isn't supported anymore. Please migrate to postgres backend. (https://github.com/dgarage/NBXplorer/blob/master/docs/Postgres-Migration.md)");
 			}
 			if (IsDbTrie && IsPostgres)
 			{


### PR DESCRIPTION
Stop supporting DBTrie backend.

This PR isn't removing any code, and it add an undocumented `NBXPLORER_ALLOW_DBTRIE` environment variable so the test can still run.

Later next year I will need to rebase https://github.com/dgarage/NBXplorer/pull/439 and completely remove DBTrie code.