### PR TITLE
Support not creating change with psbt api

### DIFF
--- a/NBXplorer.Client/Models/CreatePSBTRequest.cs
+++ b/NBXplorer.Client/Models/CreatePSBTRequest.cs
@@ -50,6 +50,16 @@ namespace NBXplorer.Models
 		public bool ReserveChangeAddress { get; set; }
 
 		/// <summary>
+		/// Use a specific change address (Optional, default: null, mutually exclusive with ReserveChangeAddress, DonateChangeToMiners)
+		/// </summary>
+		public BitcoinAddress ExplicitChangeAddress { get; set; }
+
+		/// <summary>
+		/// donate any leftover from selected coins to miners (Optional, default: false,  mutually exclusive with ReserveChangeAddress, ExplicitChangeAddress)
+		/// </summary>
+		public bool DonateChangeToMiners { get; set; }
+
+		/// <summary>
 		/// Default to 0, the minimum confirmations a UTXO need to be selected. (by default unconfirmed and confirmed UTXO will be used)
 		/// </summary>
 		public int MinConfirmations { get; set; }
@@ -67,11 +77,6 @@ namespace NBXplorer.Models
 		/// If `true`, all the UTXOs that have been selected will be used as input in the PSBT. (default to false)
 		/// </summary>
 		public bool? SpendAllMatchingOutpoints { get; set; }
-
-		/// <summary>
-		/// Use a specific change address (Optional, default: null, mutually exclusive with ReserveChangeAddress)
-		/// </summary>
-		public BitcoinAddress ExplicitChangeAddress { get; set; }
 
 		/// <summary>
 		/// Rebase the hdkey paths (if no rebase, the key paths are relative to the xpub that NBXplorer knows about)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1058,7 +1058,8 @@ Fields:
 * `rbf`: Optional, determine if the transaction should have Replace By Fee (RBF) activated (default: `true`, if `disableFingerprintRandomization` is `true`)
 * `reserveChangeAddress`: default to false, whether the creation of this PSBT will reserve a new change address.
 * `spendAllMatchingOutpoints`: If `true`, all the UTXOs that have been selected will be used as input in the PSBT. (default to false)
-* `explicitChangeAddress`: default to null, use a specific change address (Optional, mutually exclusive with reserveChangeAddress)
+* `explicitChangeAddress`: default to null, use a specific change address (Optional, mutually exclusive with reserveChangeAddress and donateChangeToMiners)
+* `donateChangeToMiners`: default to false, donate any leftover from selected coins to miners (Optional, mutually exclusive with reserveChangeAddress, explicitChangeAddress)
 * `minConfirmations`: default to 0, the minimum confirmations a UTXO need to be selected. (by default unconfirmed and confirmed UTXO will be used)
 * `includeOnlyOutpoints`: Only select the following outpoints for creating the PSBT. Note that it can also select outpoints that has been already spent, but where the spending is unconfirmed, so it can be used for RBF. (default to null)
 * `excludeOutpoints`: Do not select the following outpoints for creating the PSBT (default to empty)


### PR DESCRIPTION
This allows you to explicitly specify to donate leftover change to miners.