### PR TITLE
Add Group API

### DIFF
--- a/NBXplorer.Client/ExplorerClient.cs
+++ b/NBXplorer.Client/ExplorerClient.cs
@@ -547,6 +547,28 @@ namespace NBXplorer
 			return GenerateWalletAsync(request, cancellationToken).GetAwaiter().GetResult();
 		}
 
+		public Task<GroupInformation> CreateGroupAsync(CancellationToken cancellationToken = default)
+		{
+			return SendAsync<GroupInformation>(HttpMethod.Post, null, $"v1/groups", cancellationToken);
+		}
+		public Task<GroupInformation> GetGroupAsync(string groupId, CancellationToken cancellationToken = default)
+		{
+			return SendAsync<GroupInformation>(HttpMethod.Get, null, $"v1/groups/{groupId}", cancellationToken);
+		}
+		public Task<GroupInformation> AddGroupChildrenAsync(string groupId, GroupChild[] children, CancellationToken cancellationToken = default)
+		{
+			return SendAsync<GroupInformation>(HttpMethod.Post, children, $"v1/groups/{groupId}/children", cancellationToken);
+		}
+		public Task<GroupInformation> RemoveGroupChildrenAsync(string groupId, GroupChild[] children, CancellationToken cancellationToken = default)
+		{
+			return SendAsync<GroupInformation>(HttpMethod.Delete, children, $"v1/groups/{groupId}/children", cancellationToken);
+		}
+
+		public Task AddGroupAddressAsync(string cryptoCode, string groupId, string[] addresses, CancellationToken cancellationToken = default)
+		{
+			return SendAsync<GroupInformation>(HttpMethod.Post, addresses, $"v1/cryptos/{cryptoCode}/groups/{groupId}/addresses", cancellationToken);
+		}
+
 		private static readonly HttpClient SharedClient = new HttpClient();
 		internal HttpClient Client = SharedClient;
 

--- a/NBXplorer.Client/ExplorerClient.cs
+++ b/NBXplorer.Client/ExplorerClient.cs
@@ -726,7 +726,7 @@ namespace NBXplorer
 			{
 				DerivationSchemeTrackedSource dsts => $"v1/cryptos/{CryptoCode}/derivations/{dsts.DerivationStrategy}",
 				AddressTrackedSource asts => $"v1/cryptos/{CryptoCode}/addresses/{asts.Address}",
-				WalletTrackedSource wts => $"v1/cryptos/{CryptoCode}/wallets/{wts.WalletId}",
+				GroupTrackedSource wts => $"v1/cryptos/{CryptoCode}/groups/{wts.GroupId}",
 				_ => $"v1/cryptos/{CryptoCode}/tracked-sources/{trackedSource}"
 			};
 		}

--- a/NBXplorer.Client/Models/GenerateWalletResponse.cs
+++ b/NBXplorer.Client/Models/GenerateWalletResponse.cs
@@ -6,6 +6,7 @@ namespace NBXplorer.Models
 {
 	public class GenerateWalletResponse
 	{
+		public string TrackedSource { get; set; }
 		public string Mnemonic { get; set; }
 		public string Passphrase { get; set; }
 		[JsonConverter(typeof(NBXplorer.JsonConverters.WordlistJsonConverter))]

--- a/NBXplorer.Client/Models/GroupInformation.cs
+++ b/NBXplorer.Client/Models/GroupInformation.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NBXplorer.Models
+{
+	public class GroupChild
+	{
+		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+		public string CryptoCode { get; set; }
+		public string TrackedSource { get; set; }
+	}
+	public class GroupInformation
+	{
+		public string TrackedSource { get; set; }
+		public string GroupId { get; set; }
+		public GroupChild[] Children { get; set; }
+
+		public GroupChild AsGroupChild() => new () { TrackedSource = TrackedSource };
+	}
+}

--- a/NBXplorer.Client/Models/TrackedSource.cs
+++ b/NBXplorer.Client/Models/TrackedSource.cs
@@ -26,9 +26,9 @@ namespace NBXplorer.Models
 					return false;
 				trackedSource = addressTrackedSource;
 			}
-			else if (strSpan.StartsWith("WALLET:".AsSpan(), StringComparison.Ordinal))
+			else if (strSpan.StartsWith("GROUP:".AsSpan(), StringComparison.Ordinal))
 			{
-				if (!WalletTrackedSource.TryParse(strSpan, out var walletTrackedSource))
+				if (!GroupTrackedSource.TryParse(strSpan, out var walletTrackedSource))
 					return false;
 				trackedSource = walletTrackedSource;
 			}
@@ -103,25 +103,25 @@ namespace NBXplorer.Models
 		}
 	}
 
-	public class WalletTrackedSource : TrackedSource
+	public class GroupTrackedSource : TrackedSource
 	{
-		public string WalletId { get; }
+		public string GroupId { get; }
 
-		public WalletTrackedSource(string walletId)
+		public GroupTrackedSource(string groupId)
 		{
-			WalletId = walletId;
+			GroupId = groupId;
 		}
 
-		public static bool TryParse(ReadOnlySpan<char> strSpan, out WalletTrackedSource walletTrackedSource)
+		public static bool TryParse(ReadOnlySpan<char> trackedSource, out GroupTrackedSource walletTrackedSource)
 		{
-			if (strSpan == null)
-				throw new ArgumentNullException(nameof(strSpan));
+			if (trackedSource == null)
+				throw new ArgumentNullException(nameof(trackedSource));
 			walletTrackedSource = null;
-			if (!strSpan.StartsWith("WALLET:".AsSpan(), StringComparison.Ordinal))
+			if (!trackedSource.StartsWith("GROUP:".AsSpan(), StringComparison.Ordinal))
 				return false;
 			try
 			{
-				walletTrackedSource = new WalletTrackedSource(strSpan.Slice("WALLET:".Length).ToString());
+				walletTrackedSource = new GroupTrackedSource(trackedSource.Slice("GROUP:".Length).ToString());
 				return true;
 			}
 			catch { return false; }
@@ -129,11 +129,16 @@ namespace NBXplorer.Models
 
 		public override string ToString()
 		{
-			return "WALLET:" + WalletId;
+			return "GROUP:" + GroupId;
 		}
 		public override string ToPrettyString()
 		{
-			return WalletId;
+			return GroupId;
+		}
+
+		public static GroupTrackedSource Parse(string trackedSource)
+		{
+			return TryParse(trackedSource, out var g) ? g : throw new FormatException("Invalid group tracked source format");
 		}
 	}
 

--- a/NBXplorer.Tests/UnitTest1.Groups.cs
+++ b/NBXplorer.Tests/UnitTest1.Groups.cs
@@ -1,0 +1,136 @@
+﻿using Dapper;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
+using NBitcoin;
+using NBXplorer.Backends.Postgres;
+using NBXplorer.Controllers;
+using NBXplorer.Models;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public partial class UnitTest1
+	{
+		[Fact]
+		public async Task CanCRUDGroups()
+		{
+			using var tester = ServerTester.Create(Backend.Postgres);
+			var g1 = await tester.Client.CreateGroupAsync();
+			void AssertG1Empty()
+			{
+				Assert.NotNull(g1.GroupId);
+				Assert.NotNull(g1.TrackedSource);
+				Assert.Equal($"GROUP:{g1.GroupId}", g1.TrackedSource);
+				Assert.Empty(g1.Children);
+			}
+			AssertG1Empty();
+			g1 = await tester.Client.GetGroupAsync(g1.GroupId);
+			AssertG1Empty();
+			Assert.Null(await tester.Client.GetGroupAsync("lol"));
+			Assert.Null(await tester.Client.AddGroupChildrenAsync("lol", Array.Empty<GroupChild>()));
+
+			await AssertNBXplorerException(409, tester.Client.AddGroupChildrenAsync(g1.GroupId, [g1.AsGroupChild()]));
+			Assert.Null(await tester.Client.AddGroupChildrenAsync(g1.GroupId, [new GroupChild() { TrackedSource = "GROUP:Test" }]));
+			Assert.Null(await tester.Client.AddGroupChildrenAsync("Test", [new GroupChild() { TrackedSource = g1.TrackedSource }]));
+
+			var g2 = await tester.Client.CreateGroupAsync();
+			g1 = await tester.Client.AddGroupChildrenAsync(g1.GroupId, [g2.AsGroupChild()]);
+			Assert.NotNull(g1);
+			// Nothing happen if twice
+			g1 = await tester.Client.AddGroupChildrenAsync(g1.GroupId, [g2.AsGroupChild()]);
+			Assert.Equal(g2.TrackedSource, Assert.Single(g1.Children).TrackedSource);
+			await AssertNBXplorerException(409, tester.Client.AddGroupChildrenAsync(g2.GroupId, [g1.AsGroupChild()]));
+			g1 = await tester.Client.RemoveGroupChildrenAsync(g1.GroupId, [g2.AsGroupChild()]);
+			AssertG1Empty();
+
+			var g3 = await tester.Client.CreateGroupAsync();
+			g1 = await tester.Client.AddGroupChildrenAsync(g1.GroupId, [g2.AsGroupChild(), g3.AsGroupChild()]);
+			Assert.Equal(2, g1.Children.Length);
+
+			// Adding address in g2 should add the addresse to g1 but not g3
+			var addresses = Enumerable.Range(0,10).Select(_ => new Key().GetAddress(ScriptPubKeyType.Legacy, tester.Network).ToString()).ToArray();
+			await tester.Client.AddGroupAddressAsync("BTC", g2.GroupId, addresses);
+			// Idempotent
+			await tester.Client.AddGroupAddressAsync("BTC", g2.GroupId, addresses);
+
+			async Task AssertAddresses(GroupInformation g)
+			{
+				var groupAddresses = await GetGroupAddressesAsync(tester, "BTC", g.GroupId);
+				Assert.Equal(groupAddresses.Length, addresses.Length);
+				foreach (var a in addresses)
+				{
+					Assert.Contains(a, groupAddresses);
+				}
+			}
+			await AssertAddresses(g1);
+			await AssertAddresses(g2);
+			var g3Addrs = await GetGroupAddressesAsync(tester, "BTC", g3.GroupId);
+			Assert.Empty(g3Addrs);
+
+			// Removing g2 should remove all its addresses
+			g1 = await tester.Client.RemoveGroupChildrenAsync(g1.GroupId, [g2.AsGroupChild()]);
+			await AssertAddresses(g2);
+			var g1Addrs = await GetGroupAddressesAsync(tester, "BTC", g1.GroupId);
+			Assert.Empty(g1Addrs);
+
+			await AssertNBXplorerException(400, tester.Client.AddGroupChildrenAsync(g2.GroupId, [new GroupChild() { TrackedSource= "DERIVATIONSCHEME:tpubDC45vUDsFAAqwYKz5hSLi5yJLNduJzpmTw6QTMRPrwdXURoyL81H8oZAaL8EiwEgg92qgMa9h1bB4Y1BZpy9CTNPfjfxvFcWxeiKBHCqSdc" }]));
+			await AssertNBXplorerException(400, tester.Client.AddGroupChildrenAsync(g2.GroupId, [new GroupChild() { CryptoCode="BTC", TrackedSource = "DERIVATIONSCHEME:lol" }]));
+		}
+
+		private async Task<string[]> GetGroupAddressesAsync(ServerTester tester, string code, string groupId)
+		{
+			await using var conn = await tester.GetService<DbConnectionFactory>().CreateConnection();
+			return (await conn.QueryAsync<string>("SELECT s.addr FROM wallets_scripts JOIN scripts s USING (code, script) WHERE code=@code AND wallet_id=@wid", new
+			{
+				code = code,
+				wid = PostgresRepository.GetWalletKey(new GroupTrackedSource(groupId)).wid
+			})).ToArray();
+		}
+
+		[Fact]
+		public async Task CanAliceAndBobShareWallet()
+		{
+			using var tester = ServerTester.Create(Backend.Postgres);
+			var bobW = tester.Client.GenerateWallet(new GenerateWalletRequest() { ScriptPubKeyType = ScriptPubKeyType.Segwit });
+			var aliceW = tester.Client.GenerateWallet(new GenerateWalletRequest() { ScriptPubKeyType = ScriptPubKeyType.Segwit });
+
+			var shared = await tester.Client.CreateGroupAsync();
+			await tester.Client.AddGroupChildrenAsync(shared.GroupId, new[] { bobW, aliceW }.Select(w => new GroupChild() { CryptoCode = "BTC", TrackedSource = w.TrackedSource }).ToArray());
+
+			var unused = tester.Client.GetUnused(bobW.DerivationScheme, DerivationStrategy.DerivationFeature.Deposit);
+			var txid = tester.SendToAddress(unused.Address, Money.Coins(1.0m));
+			var gts = GroupTrackedSource.Parse(shared.TrackedSource);
+			tester.Notifications.WaitForTransaction(gts, txid);
+
+			var balance = await tester.Client.GetBalanceAsync(gts);
+			Assert.Equal(Money.Coins(1.0m), balance.Unconfirmed);
+
+			var txs = await tester.Client.GetTransactionsAsync(gts);
+			var tx = Assert.Single(txs.UnconfirmedTransactions.Transactions);
+			Assert.Equal(txid, tx.TransactionId);
+			Assert.NotNull(tx.Outputs[0].Address);
+
+			// Can we track manually added address?
+			await tester.Client.AddGroupAddressAsync("BTC", shared.GroupId, ["n3XyBWEKWLxm5EzrrvLCJyCQrRhVWQ8YGa"]);
+			txid = tester.SendToAddress(BitcoinAddress.Create("n3XyBWEKWLxm5EzrrvLCJyCQrRhVWQ8YGa", tester.Network), Money.Coins(1.2m));
+			var txEvt = tester.Notifications.WaitForTransaction(gts, txid);
+			Assert.Single(txEvt.Outputs);
+			Assert.NotNull(tx.Outputs[0].Address);
+
+			balance = await tester.Client.GetBalanceAsync(gts);
+			Assert.Equal(Money.Coins(1.0m + 1.2m), balance.Unconfirmed);
+		}
+
+		private async Task<NBXplorerException> AssertNBXplorerException(int httpCode, Task<GroupInformation> task)
+		{
+			var ex = await Assert.ThrowsAsync<NBXplorerException>(() => task);
+			Assert.Equal(httpCode, ex.Error.HttpCode);
+			return ex;
+		}
+	}
+}

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -30,7 +30,7 @@ using NBXplorer.HostedServices;
 
 namespace NBXplorer.Tests
 {
-	public class UnitTest1
+	public partial class UnitTest1
 	{
 		public UnitTest1(ITestOutputHelper helper)
 		{

--- a/NBXplorer/Backends/DBTrie/Repository.cs
+++ b/NBXplorer/Backends/DBTrie/Repository.cs
@@ -1411,7 +1411,7 @@ namespace NBXplorer.Backends.DBTrie
 			}
 			foreach (var m in matches.Values)
 			{
-				m.KnownKeyPathMappingUpdated();
+				m.OwnedScriptsUpdated();
 				await AfterMatch(m, keyPathInformationsByTrackedTransaction[m]);
 			}
 

--- a/NBXplorer/Backends/Postgres/PostgresRepository.cs
+++ b/NBXplorer/Backends/Postgres/PostgresRepository.cs
@@ -198,39 +198,41 @@ namespace NBXplorer.Backends.Postgres
 		}
 		// metadata isn't really part of the key, but it's handy to have it here when we do INSERT INTO wallets.
 		public record WalletKey(string wid, string metadata);
-		internal WalletKey GetWalletKey(DerivationStrategyBase strategy)
+		internal static WalletKey GetWalletKey(DerivationStrategyBase strategy, NBXplorerNetwork network)
 		{
-			var hash = DBUtils.nbxv1_get_wallet_id(Network.CryptoCode, strategy.ToString());
+			var hash = DBUtils.nbxv1_get_wallet_id(network.CryptoCode, strategy.ToString());
 			JObject m = new JObject();
 			m.Add(new JProperty("type", new JValue("NBXv1-Derivation")));
-			m.Add(new JProperty("code", new JValue(Network.CryptoCode)));
+			m.Add(new JProperty("code", new JValue(network.CryptoCode)));
 			m.Add(new JProperty("derivation", new JValue(strategy.ToString())));
 			return new WalletKey(hash, m.ToString(Formatting.None));
 		}
-		WalletKey GetWalletKey(GroupTrackedSource groupTrackedSource)
+		internal static WalletKey GetWalletKey(GroupTrackedSource groupTrackedSource)
 		{
 			var m = new JObject { new JProperty("type", new JValue("NBXv1-Group")) };
 			var res = new WalletKey($"G:" + groupTrackedSource.GroupId, m.ToString(Formatting.None));
 			return res;
 		}
-		WalletKey GetWalletKey(IDestination destination)
+		internal static WalletKey GetWalletKey(IDestination destination, NBXplorerNetwork network)
 		{
-			var address = destination.ScriptPubKey.GetDestinationAddress(Network.NBitcoinNetwork);
-			var hash = DBUtils.nbxv1_get_wallet_id(Network.CryptoCode, address.ToString());
+			var address = destination.ScriptPubKey.GetDestinationAddress(network.NBitcoinNetwork);
+			var hash = DBUtils.nbxv1_get_wallet_id(network.CryptoCode, address.ToString());
 			JObject m = new JObject();
 			m.Add(new JProperty("type", new JValue("NBXv1-Address")));
-			m.Add(new JProperty("code", new JValue(Network.CryptoCode)));
+			m.Add(new JProperty("code", new JValue(network.CryptoCode)));
 			m.Add(new JProperty("address", new JValue(address.ToString())));
 			return new WalletKey(hash, m.ToString(Formatting.None));
 		}
-		internal WalletKey GetWalletKey(TrackedSource source)
+
+		internal WalletKey GetWalletKey(TrackedSource source) => GetWalletKey(source, Network);
+		internal static WalletKey GetWalletKey(TrackedSource source, NBXplorerNetwork network)
 		{
 			if (source is null)
 				throw new ArgumentNullException(nameof(source));
 			return source switch
 			{
-				DerivationSchemeTrackedSource derivation => GetWalletKey(derivation.DerivationStrategy),
-				AddressTrackedSource addr => GetWalletKey(addr.Address),
+				DerivationSchemeTrackedSource derivation => GetWalletKey(derivation.DerivationStrategy, network),
+				AddressTrackedSource addr => GetWalletKey(addr.Address, network),
 				GroupTrackedSource group => GetWalletKey(group),
 				_ => throw new NotSupportedException(source.GetType().ToString())
 			};
@@ -238,12 +240,16 @@ namespace NBXplorer.Backends.Postgres
 
 		internal TrackedSource TryGetTrackedSource(WalletKey walletKey)
 		{
+			return TryGetTrackedSource(walletKey, Network);
+		}
+		internal static TrackedSource TryGetTrackedSource(WalletKey walletKey, NBXplorerNetwork network)
+		{
 			var metadata = JObject.Parse(walletKey.metadata);
 			if (metadata.TryGetValue("type", StringComparison.OrdinalIgnoreCase, out JToken typeJToken) &&
 				typeJToken.Value<string>() is { } type)
 			{
 				if ((metadata.TryGetValue("code", StringComparison.OrdinalIgnoreCase, out JToken codeJToken) &&
-					 codeJToken.Value<string>() is { } code) && !code.Equals(Network.CryptoCode,
+					 codeJToken.Value<string>() is { } code) && !code.Equals(network.CryptoCode,
 						StringComparison.InvariantCultureIgnoreCase))
 				{
 					return null;
@@ -253,10 +259,10 @@ namespace NBXplorer.Backends.Postgres
 				{
 					case "NBXv1-Derivation":
 						var derivation = metadata["derivation"].Value<string>();
-						return new DerivationSchemeTrackedSource(Network.DerivationStrategyFactory.Parse(derivation));
+						return new DerivationSchemeTrackedSource(network.DerivationStrategyFactory.Parse(derivation));
 					case "NBXv1-Address":
 						var address = metadata["address"].Value<string>();
-						return new AddressTrackedSource(BitcoinAddress.Create(address, Network.NBitcoinNetwork));
+						return new AddressTrackedSource(BitcoinAddress.Create(address, network.NBitcoinNetwork));
 					case "NBXv1-Group":
 						return new GroupTrackedSource(walletKey.wid[2..]); // Skip "G:"
 				}
@@ -277,7 +283,7 @@ namespace NBXplorer.Backends.Postgres
 		internal async Task<int> GenerateAddressesCore(DbConnection connection, DerivationStrategyBase strategy, DerivationFeature derivationFeature, GenerateAddressQuery query)
 		{
 			var descriptorKey = GetDescriptorKey(strategy, derivationFeature);
-			var walletKey = GetWalletKey(strategy);
+			var walletKey = GetWalletKey(strategy, Network);
 			var gapNextIndex = await GetGapAndNextIdx(connection, descriptorKey);
 			long toGenerate = ToGenerateCount(query, gapNextIndex?.gap);
 			if (gapNextIndex is not null && toGenerate == 0)
@@ -399,10 +405,11 @@ namespace NBXplorer.Backends.Postgres
 							"WHERE code=@code AND descriptor=@descriptor", descriptorKey);
 		}
 
+		internal const string InsertScriptsScript = "INSERT INTO scripts (code, script, addr, used) SELECT @code code, script, addr, used FROM unnest(@records) ON CONFLICT DO NOTHING;";
 		private async Task InsertDescriptorsScripts(DbConnection connection, IList<DescriptorScriptInsert> batch)
 		{
 			await connection.ExecuteAsync(
-								"INSERT INTO scripts (code, script, addr, used) SELECT @code code, script, addr, used FROM unnest(@records) ON CONFLICT DO NOTHING;" +
+								InsertScriptsScript +
 								"INSERT INTO descriptors_scripts (code, descriptor, idx, script, metadata, used) SELECT @code code, descriptor, idx, script, metadata, used FROM unnest(@records) ON CONFLICT DO NOTHING;"
 								, new
 								{
@@ -489,7 +496,7 @@ namespace NBXplorer.Backends.Postgres
 			var rows = await connection.QueryAsync($@"
 			    SELECT ts.code, ts.script, ts.addr, ts.derivation, ts.keypath, ts.redeem{additionalColumn},
 				       ts.wallet_id,
-				       w.metadata->>'type' AS wallet_metadata
+				       w.metadata AS wallet_metadata
 				FROM unnest(@records) AS r (script),
 				LATERAL (
 				    SELECT code, script, wallet_id, addr, descriptor_metadata->>'derivation' derivation, 
@@ -766,7 +773,7 @@ namespace NBXplorer.Backends.Postgres
 					}
 					foreach (var m in matches.Values)
 					{
-						m.KnownKeyPathMappingUpdated();
+						m.OwnedScriptsUpdated();
 						if (elementContext is not null)
 							await elementContext.Unblind(rpc, m);
 					}
@@ -834,9 +841,9 @@ namespace NBXplorer.Backends.Postgres
 			var tip = await connection.GetTip();
 			var txIdCond = txId is null ? string.Empty : " AND tx_id=@tx_id";
 			var utxos = await
-				connection.Connection.QueryAsync<(string tx_id, long idx, string blk_id, long? blk_height, int? blk_idx, bool is_out, string spent_tx_id, long spent_idx, string script, long value, string asset_id, bool immature, string keypath, DateTime seen_at)>(
-				"SELECT tx_id, idx, blk_id, blk_height, blk_idx, is_out, spent_tx_id, spent_idx, script, value, asset_id, immature, keypath, seen_at " +
-				"FROM nbxv1_tracked_txs " +
+				connection.Connection.QueryAsync<(string tx_id, long idx, string blk_id, long? blk_height, int? blk_idx, bool is_out, string spent_tx_id, long spent_idx, string script, string addr, long value, string asset_id, bool immature, string keypath, DateTime seen_at)>(
+				"SELECT tx_id, idx, blk_id, blk_height, blk_idx, is_out, spent_tx_id, spent_idx, script, s.addr, value, asset_id, immature, keypath, seen_at " +
+				"FROM nbxv1_tracked_txs LEFT JOIN scripts s USING (code, script) " +
 				$"WHERE code=@code AND wallet_id=@walletId{txIdCond}", new { code = Network.CryptoCode, walletId = GetWalletKey(trackedSource).wid, tx_id = txId?.ToString() });
 			utxos.TryGetNonEnumeratedCount(out int c);
 			var trackedById = new Dictionary<string, TrackedTransaction>(c);
@@ -847,6 +854,7 @@ namespace NBXplorer.Backends.Postgres
 				{
 					var txout = Network.NBitcoinNetwork.Consensus.ConsensusFactory.CreateTxOut();
 					txout.ScriptPubKey = Script.FromHex(utxo.script);
+					tracked.KnownAddresses.TryAdd(txout.ScriptPubKey, BitcoinAddress.Create(utxo.addr, this.Network.NBitcoinNetwork));
 					txout.Value = Money.Satoshis(utxo.value);
 					var coin = new Coin(new OutPoint(tracked.Key.TxId, (uint)utxo.idx), txout);
 					if (Network.IsElement)
@@ -857,11 +865,13 @@ namespace NBXplorer.Backends.Postgres
 					{
 						tracked.ReceivedCoins.Add(coin);
 					}
+
 					// TODO: IsCoinBase is actually not used anywhere.
 					tracked.IsCoinBase = utxo.immature;
 					tracked.Immature = utxo.immature;
 					if (utxo.keypath is string)
 						tracked.KnownKeyPathMapping.TryAdd(txout.ScriptPubKey, KeyPath.Parse(utxo.keypath));
+					tracked.OwnedScripts.Add(txout.ScriptPubKey);
 				}
 				else
 				{
@@ -889,7 +899,7 @@ namespace NBXplorer.Backends.Postgres
 
 			return trackedById.Values.Select(c =>
 			{
-				c.KnownKeyPathMappingUpdated();
+				c.OwnedScriptsUpdated();
 				return c;
 			}).ToArray();
 		}
@@ -1241,7 +1251,7 @@ namespace NBXplorer.Backends.Postgres
 		public async Task Track(IDestination address)
 		{
 			await using var conn = await GetConnection();
-			var walletKey = GetWalletKey(address);
+			var walletKey = GetWalletKey(address, Network);
 			await conn.Connection.ExecuteAsync(
 				WalletInsertQuery +
 				"INSERT INTO scripts VALUES (@code, @script, @addr) ON CONFLICT DO NOTHING;" +
@@ -1331,12 +1341,11 @@ namespace NBXplorer.Backends.Postgres
 
 		public async Task EnsureWalletCreated(DerivationStrategyBase strategy)
 		{
-			await EnsureWalletCreated(GetWalletKey(strategy));
+			await EnsureWalletCreated(GetWalletKey(strategy, Network));
 		}
 
-		public async Task EnsureWalletCreated(TrackedSource trackedSource, params TrackedSource[] parentTrackedSource)
+		public async Task EnsureWalletCreated(TrackedSource trackedSource)
 		{
-			parentTrackedSource = parentTrackedSource.Where(source => source is not null).ToArray();
 			await EnsureWalletCreated(GetWalletKey(trackedSource));
 		}
 
@@ -1347,7 +1356,7 @@ namespace NBXplorer.Backends.Postgres
 			await connection.ExecuteAsync(WalletInsertQuery, walletKey);
 		}
 
-		private readonly string WalletInsertQuery = "INSERT INTO wallets (wallet_id, metadata) VALUES (@wid, @metadata::JSONB) ON CONFLICT DO NOTHING;";
+		internal static readonly string WalletInsertQuery = "INSERT INTO wallets (wallet_id, metadata) VALUES (@wid, @metadata::JSONB) ON CONFLICT DO NOTHING;";
 	}
 
 	public class LegacyDescriptorMetadata

--- a/NBXplorer/Controllers/CommonRoutes.cs
+++ b/NBXplorer/Controllers/CommonRoutes.cs
@@ -6,7 +6,7 @@ public static class CommonRoutes
 	public const string BaseDerivationEndpoint = $"{BaseCryptoEndpoint}/derivations";
 	public const string DerivationEndpoint =  $"{BaseCryptoEndpoint}/derivations/{{derivationScheme}}";
 	public const string AddressEndpoint =  $"{BaseCryptoEndpoint}/addresses/{{address}}";
-	public const string WalletEndpoint =  $"{BaseCryptoEndpoint}/wallets/{{walletId}}";
+	public const string GroupEndpoint =  $"{BaseCryptoEndpoint}/groups/{{groupId}}";
 	public const string TrackedSourceEndpoint =  $"{BaseCryptoEndpoint}/tracked-sources/{{trackedSource}}";
 	public const string TransactionsPath = "transactions/{txId?}";
 }

--- a/NBXplorer/Controllers/CommonRoutes.cs
+++ b/NBXplorer/Controllers/CommonRoutes.cs
@@ -6,7 +6,7 @@ public static class CommonRoutes
 	public const string BaseDerivationEndpoint = $"{BaseCryptoEndpoint}/derivations";
 	public const string DerivationEndpoint =  $"{BaseCryptoEndpoint}/derivations/{{derivationScheme}}";
 	public const string AddressEndpoint =  $"{BaseCryptoEndpoint}/addresses/{{address}}";
-	public const string GroupEndpoint =  $"{BaseCryptoEndpoint}/groups/{{groupId}}";
-	public const string TrackedSourceEndpoint =  $"{BaseCryptoEndpoint}/tracked-sources/{{trackedSource}}";
+	public const string BaseGroupEndpoint = $"groups";
+	public const string GroupEndpoint =  $"{BaseGroupEndpoint}/{{groupId}}";
 	public const string TransactionsPath = "transactions/{txId?}";
 }

--- a/NBXplorer/Controllers/GroupsController.cs
+++ b/NBXplorer/Controllers/GroupsController.cs
@@ -1,0 +1,177 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using NBitcoin;
+using NBXplorer.DerivationStrategy;
+using NBXplorer.ModelBinders;
+using NBXplorer.Models;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NBitcoin.RPC;
+using NBXplorer.Analytics;
+using NBXplorer.Backends;
+using NBXplorer.Backends.Postgres;
+using Dapper;
+using Microsoft.AspNetCore.Http;
+using static NBXplorer.Backends.Postgres.PostgresRepository;
+using Microsoft.AspNetCore.Authorization;
+using RabbitMQ.Client;
+using Npgsql;
+using NBitcoin.Crypto;
+using static NBitcoin.Scripting.OutputDescriptor;
+using NBitcoin.Protocol;
+
+namespace NBXplorer.Controllers
+{
+	[Route($"v1")]
+	[PostgresImplementationActionConstraint(true)]
+	[Authorize]
+	public class GroupsController : Controller
+	{
+		public GroupsController(
+		DbConnectionFactory connectionFactory,
+		NBXplorerNetworkProvider networkProvider)
+		{
+			ConnectionFactory = connectionFactory;
+			NetworkProvider = networkProvider;
+		}
+		public DbConnectionFactory ConnectionFactory { get; }
+		public NBXplorerNetworkProvider NetworkProvider { get; }
+
+		[HttpPost(CommonRoutes.BaseGroupEndpoint)]
+		public async Task<IActionResult> CreateGroup()
+		{
+			var group = GroupTrackedSource.Generate();
+			await using var conn = await ConnectionFactory.CreateConnection();
+			await conn.ExecuteAsync(PostgresRepository.WalletInsertQuery, PostgresRepository.GetWalletKey(group));
+			return base.Ok(ToGroupInfo(group));
+		}
+
+		[HttpGet(CommonRoutes.GroupEndpoint)]
+		public async Task<IActionResult> GetGroup(string groupId)
+		{
+			var group = new GroupTrackedSource(groupId);
+			var w = PostgresRepository.GetWalletKey(new GroupTrackedSource(groupId));
+			await using var conn = await ConnectionFactory.CreateConnection();
+			var children = (await conn.QueryAsync<WalletKey>(
+				"SELECT wc.wallet_id wid, wc.metadata FROM wallets w " +
+				"LEFT JOIN wallets_wallets ww ON ww.parent_id=w.wallet_id " +
+				"LEFT JOIN wallets wc ON wc.wallet_id=ww.wallet_id " +
+				"WHERE w.wallet_id=@wid", new { w.wid })).ToArray();
+			if (children.Length == 0)
+				throw GroupNotFound();
+			var groupInfo = ToGroupInfo(group);
+			if (!(children.Length is 1 && children[0].wid is null))
+				groupInfo.Children = ToGroupChildren(children);
+			return Ok(groupInfo);
+		}
+
+		private static NBXplorerException GroupNotFound()
+		{
+			return new NBXplorerException(new NBXplorerError(404, "group-not-found", "The group doesn't exist"));
+		}
+
+		private GroupChild[] ToGroupChildren(WalletKey[] children) => children.Select(x => ToGroupChild(x)).Where(x => x is not null).ToArray();
+
+		private GroupChild ToGroupChild(WalletKey walletKey)
+		{
+			if (walletKey is null)
+				return null;
+			var cryptoCode = JObject.Parse(walletKey.metadata)["code"]?.Value<string>();
+			NBXplorerNetwork net = null;
+			if (cryptoCode != null)
+			{
+				net = NetworkProvider.GetFromCryptoCode(cryptoCode);
+				if (net is null)
+					return null;
+			}
+			var trackedSource = PostgresRepository.TryGetTrackedSource(walletKey, net);
+			return new GroupChild() { CryptoCode = net?.CryptoCode, TrackedSource = trackedSource.ToString() };
+		}
+
+		[HttpPost($"{CommonRoutes.GroupEndpoint}/children")]
+		[HttpDelete($"{CommonRoutes.GroupEndpoint}/children")]
+		public async Task<IActionResult> AddDeleteGroupChildren(string groupId, [FromBody] GroupChild[] children)
+		{
+			var w = PostgresRepository.GetWalletKey(new GroupTrackedSource(groupId));
+			await using (var conn = await ConnectionFactory.CreateConnection())
+			{
+				var rows = children
+						.Select(c => GetWid(c))
+						.Where(c => c is not null)
+						.Select(c => new { child = c, w.wid }).ToArray();
+				if (HttpContext.Request.Method == "POST")
+					try
+					{
+						await conn.ExecuteAsync("INSERT INTO wallets_wallets VALUES (@child, @wid) ON CONFLICT (wallet_id, parent_id) DO NOTHING", rows);
+					}
+					catch (NpgsqlException ex) when (ex.SqlState == PostgresErrorCodes.RaiseException)
+					{
+						throw new NBXplorerException(new NBXplorerError(409, "cycle-detected", "A cycle has been detected"));
+					}
+					catch (NpgsqlException ex) when (ex.SqlState == PostgresErrorCodes.ForeignKeyViolation)
+					{
+						throw GroupNotFound();
+					}
+				if (HttpContext.Request.Method == "DELETE")
+					await conn.ExecuteAsync("DELETE FROM wallets_wallets WHERE wallet_id=@child AND parent_id=@wid;", rows);
+			}
+			return await GetGroup(groupId);
+		}
+
+		[HttpPost($"{CommonRoutes.BaseCryptoEndpoint}/{CommonRoutes.GroupEndpoint}/addresses")]
+		public async Task<IActionResult> AddGroupAddress(TrackedSourceContext trackedSourceContext, [FromBody] string[] addresses)
+		{
+			var group = (GroupTrackedSource)trackedSourceContext.TrackedSource;
+			IList<DescriptorScriptInsert> rows;
+			try
+			{
+				rows = addresses
+					.Where(a => a is not null)
+					.Select(a => BitcoinAddress.Create(a, trackedSourceContext.Network.NBitcoinNetwork))
+					.Select(a => new DescriptorScriptInsert("", 0, a.ScriptPubKey.ToHex(), "{}", a.ToString(), false))
+					.ToList();
+			}
+			catch (FormatException)
+			{
+				throw new NBXplorerException(new NBXplorerError(400, "invalid-address",
+					$"An address cannot be parsed"));
+			}
+			await using (var conn = await ConnectionFactory.CreateConnection())
+			{
+				await conn.ExecuteAsync(PostgresRepository.InsertScriptsScript +
+					"INSERT INTO wallets_scripts (code, script, wallet_id) SELECT @code code, script, @wid FROM unnest(@records) ON CONFLICT DO NOTHING;",
+					new
+					{
+						code = trackedSourceContext.Network.CryptoCode,
+						wid = PostgresRepository.GetWalletKey(group).wid,
+						records = rows
+					});
+			}
+			return Ok();
+		}
+
+		private string GetWid(GroupChild c)
+		{
+			if (c?.TrackedSource is null)
+				return null;
+			var net = c.CryptoCode is null ? null : NetworkProvider.GetFromCryptoCode(c.CryptoCode);
+			if (c.TrackedSource.StartsWith("ADDRESS:") || c.TrackedSource.StartsWith("DERIVATIONSCHEME:") && c.CryptoCode is null)
+				throw new NBXplorerException(new NBXplorerError(400, "invalid-group-child", "ADDRESS: and DERIVATIONSCHEME: tracked sources must also include a cryptoCode parameter"));
+			if (!TrackedSource.TryParse(c.TrackedSource, out var ts, net))
+				throw new NBXplorerException(new NBXplorerError(400, "invalid-group-child", "Invalid tracked source format"));
+			return PostgresRepository.GetWalletKey(ts, net)?.wid;
+		}
+
+		private static GroupInformation ToGroupInfo(GroupTrackedSource group)
+		{
+			return new GroupInformation()
+			{
+				TrackedSource = group.ToString(),
+				GroupId = group.GroupId,
+				Children = Array.Empty<GroupChild>()
+			};
+		}
+	}
+}

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -505,7 +505,7 @@ namespace NBXplorer.Controllers
 		[HttpPost]
 		[Route($"{CommonRoutes.DerivationEndpoint}")]
 		[Route($"{CommonRoutes.AddressEndpoint}")]
-		[Route($"{CommonRoutes.WalletEndpoint}")]
+		[Route($"{CommonRoutes.GroupEndpoint}")]
 		[Route($"{CommonRoutes.TrackedSourceEndpoint}")]
 		public async Task<IActionResult> TrackWallet(
 			TrackedSourceContext trackedSourceContext,
@@ -560,7 +560,7 @@ namespace NBXplorer.Controllers
 		[HttpGet]
 		[Route($"{CommonRoutes.DerivationEndpoint}/{CommonRoutes.TransactionsPath}")]
 		[Route($"{CommonRoutes.AddressEndpoint}/{CommonRoutes.TransactionsPath}")]
-		[Route($"{CommonRoutes.WalletEndpoint}/{CommonRoutes.TransactionsPath}")]
+		[Route($"{CommonRoutes.GroupEndpoint}/{CommonRoutes.TransactionsPath}")]
 		[Route($"{CommonRoutes.TrackedSourceEndpoint}/{CommonRoutes.TransactionsPath}")]
 		public async Task<IActionResult> GetTransactions(
 			TrackedSourceContext trackedSourceContext,

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -25,7 +25,6 @@ using NBXplorer.Analytics;
 using NBXplorer.Backends;
 using NBitcoin.Scripting;
 using System.Globalization;
-using NBXplorer.Backends.Postgres;
 
 namespace NBXplorer.Controllers
 {
@@ -505,8 +504,6 @@ namespace NBXplorer.Controllers
 		[HttpPost]
 		[Route($"{CommonRoutes.DerivationEndpoint}")]
 		[Route($"{CommonRoutes.AddressEndpoint}")]
-		[Route($"{CommonRoutes.GroupEndpoint}")]
-		[Route($"{CommonRoutes.TrackedSourceEndpoint}")]
 		public async Task<IActionResult> TrackWallet(
 			TrackedSourceContext trackedSourceContext,
 			[FromBody] JObject rawRequest = null)
@@ -560,8 +557,7 @@ namespace NBXplorer.Controllers
 		[HttpGet]
 		[Route($"{CommonRoutes.DerivationEndpoint}/{CommonRoutes.TransactionsPath}")]
 		[Route($"{CommonRoutes.AddressEndpoint}/{CommonRoutes.TransactionsPath}")]
-		[Route($"{CommonRoutes.GroupEndpoint}/{CommonRoutes.TransactionsPath}")]
-		[Route($"{CommonRoutes.TrackedSourceEndpoint}/{CommonRoutes.TransactionsPath}")]
+		[Route($"{CommonRoutes.BaseCryptoEndpoint}/{CommonRoutes.GroupEndpoint}/{CommonRoutes.TransactionsPath}")]
 		public async Task<IActionResult> GetTransactions(
 			TrackedSourceContext trackedSourceContext,
 			[ModelBinder(BinderType = typeof(UInt256ModelBinding))]
@@ -760,15 +756,18 @@ namespace NBXplorer.Controllers
 			}
 		}
 
-		[HttpPost]
-		[Route($"{CommonRoutes.DerivationEndpoint}/metadata/{{key}}")]
+		[HttpPost($"{CommonRoutes.DerivationEndpoint}/metadata/{{key}}")]
+		[HttpPost($"{CommonRoutes.AddressEndpoint}/metadata/{{key}}")]
+		[HttpPost($"{CommonRoutes.GroupEndpoint}/metadata/{{key}}")]
 		public async Task<IActionResult> SetMetadata(TrackedSourceContext trackedSourceContext, string key, [FromBody] JToken value = null)
 		{
 			await trackedSourceContext.Repository.SaveMetadata(trackedSourceContext.TrackedSource, key, value);
 			return Ok();
 		}
-		[HttpGet]
-		[Route($"{CommonRoutes.DerivationEndpoint}/metadata/{{key}}")]
+
+		[HttpGet($"{CommonRoutes.DerivationEndpoint}/metadata/{{key}}")]
+		[HttpGet($"{CommonRoutes.AddressEndpoint}/metadata/{{key}}")]
+		[HttpGet($"{CommonRoutes.GroupEndpoint}/metadata/{{key}}")]
 		public async Task<IActionResult> GetMetadata(TrackedSourceContext trackedSourceContext, string key)
 		{
 			var result = await trackedSourceContext.Repository.GetMetadata<JToken>(trackedSourceContext.TrackedSource, key);
@@ -1101,6 +1100,7 @@ namespace NBXplorer.Controllers
 			});
 			return Json(new GenerateWalletResponse()
 			{
+				TrackedSource = new DerivationSchemeTrackedSource(derivation).ToString(),
 				MasterHDKey = masterKey,
 				AccountHDKey = accountKey,
 				AccountKeyPath = accountKeyPath,

--- a/NBXplorer/Controllers/PostgresMainController.cs
+++ b/NBXplorer/Controllers/PostgresMainController.cs
@@ -22,8 +22,7 @@ namespace NBXplorer.Controllers
 	[PostgresImplementationActionConstraint(true)]
 	[Route($"v1/{CommonRoutes.DerivationEndpoint}")]
 	[Route($"v1/{CommonRoutes.AddressEndpoint}")]
-	[Route($"v1/{CommonRoutes.GroupEndpoint}")]
-	[Route($"v1/{CommonRoutes.TrackedSourceEndpoint}")]
+	[Route($"v1/{CommonRoutes.BaseCryptoEndpoint}/{CommonRoutes.GroupEndpoint}")]
 	[Authorize]
 	public class PostgresMainController : Controller, IUTXOService
 	{

--- a/NBXplorer/Controllers/PostgresMainController.cs
+++ b/NBXplorer/Controllers/PostgresMainController.cs
@@ -22,7 +22,7 @@ namespace NBXplorer.Controllers
 	[PostgresImplementationActionConstraint(true)]
 	[Route($"v1/{CommonRoutes.DerivationEndpoint}")]
 	[Route($"v1/{CommonRoutes.AddressEndpoint}")]
-	[Route($"v1/{CommonRoutes.WalletEndpoint}")]
+	[Route($"v1/{CommonRoutes.GroupEndpoint}")]
 	[Route($"v1/{CommonRoutes.TrackedSourceEndpoint}")]
 	[Authorize]
 	public class PostgresMainController : Controller, IUTXOService

--- a/NBXplorer/Controllers/TrackedSourceContext.cs
+++ b/NBXplorer/Controllers/TrackedSourceContext.cs
@@ -51,7 +51,7 @@ public class TrackedSourceContext
 			var addressValue = bindingContext.ValueProvider.GetValue("address").FirstValue;
 			var derivationSchemeValue = bindingContext.ValueProvider.GetValue("derivationScheme").FirstValue;
 			derivationSchemeValue ??= bindingContext.ValueProvider.GetValue("extPubKey").FirstValue;
-			var walletIdValue = bindingContext.ValueProvider.GetValue("walletId").FirstValue;
+			var groupIdValue = bindingContext.ValueProvider.GetValue("groupId").FirstValue;
 			var trackedSourceValue = bindingContext.ValueProvider.GetValue("trackedSource").FirstValue;
 
 			var networkProvider = bindingContext.HttpContext.RequestServices.GetService<NBXplorerNetworkProvider>();
@@ -82,7 +82,7 @@ public class TrackedSourceContext
 				ThrowRpcUnavailableException();
 			}
 
-			var ts = GetTrackedSource(derivationSchemeValue, addressValue, walletIdValue,
+			var ts = GetTrackedSource(derivationSchemeValue, addressValue, groupIdValue,
 				trackedSourceValue,
 				network);
 			if (ts is null && requirements?.RequireTrackedSource is true)
@@ -117,7 +117,7 @@ public class TrackedSourceContext
 			throw new NBXplorerError(400, "rpc-unavailable", $"The RPC interface is currently not available.").AsException();
 		}
 
-		public static TrackedSource GetTrackedSource(string derivationScheme, string address, string walletId,
+		public static TrackedSource GetTrackedSource(string derivationScheme, string address, string groupId,
 			string trackedSource, NBXplorerNetwork network)
 		{
 			if (trackedSource != null)
@@ -126,8 +126,8 @@ public class TrackedSourceContext
 				return new AddressTrackedSource(BitcoinAddress.Create(address, network.NBitcoinNetwork));
 			if (derivationScheme != null)
 				return new DerivationSchemeTrackedSource(network.DerivationStrategyFactory.Parse(derivationScheme));
-			if (walletId != null)
-				return new WalletTrackedSource(walletId);
+			if (groupId != null)
+				return new GroupTrackedSource(groupId);
 			return null;
 		}
 	}

--- a/NBXplorer/DBScripts/022.WalletsWalletsParentIdIndex.sql
+++ b/NBXplorer/DBScripts/022.WalletsWalletsParentIdIndex.sql
@@ -1,0 +1,1 @@
+﻿CREATE INDEX IF NOT EXISTS wallets_wallets_parent_id   ON wallets_wallets (parent_id);

--- a/NBXplorer/DBScripts/FullSchema.sql
+++ b/NBXplorer/DBScripts/FullSchema.sql
@@ -1229,6 +1229,8 @@ CREATE INDEX wallets_history_by_seen_at ON wallets_history USING btree (seen_at)
 
 CREATE UNIQUE INDEX wallets_history_pk ON wallets_history USING btree (wallet_id, code, asset_id, tx_id);
 
+CREATE INDEX wallets_wallets_parent_id ON wallets_wallets USING btree (parent_id);
+
 CREATE TRIGGER blks_confirmed_trigger AFTER UPDATE ON blks FOR EACH ROW EXECUTE FUNCTION public.blks_confirmed_update_txs();
 
 CREATE TRIGGER blks_txs_insert_trigger AFTER INSERT ON blks_txs FOR EACH ROW EXECUTE FUNCTION public.blks_txs_denormalize();
@@ -1364,6 +1366,7 @@ INSERT INTO nbxv1_migrations VALUES ('018.FastWalletRecent');
 INSERT INTO nbxv1_migrations VALUES ('019.FixDoubleSpendDetection2');
 INSERT INTO nbxv1_migrations VALUES ('020.ReplacingShouldBeIdempotent');
 INSERT INTO nbxv1_migrations VALUES ('021.KeyPathInfoReturnsWalletId');
+INSERT INTO nbxv1_migrations VALUES ('022.WalletsWalletsParentIdIndex');
 
 ALTER TABLE ONLY nbxv1_migrations
     ADD CONSTRAINT nbxv1_migrations_pkey PRIMARY KEY (script_name);

--- a/NBXplorer/HostedServices/DBTrieToPostgresMigratorHostedService.cs
+++ b/NBXplorer/HostedServices/DBTrieToPostgresMigratorHostedService.cs
@@ -351,7 +351,7 @@ namespace NBXplorer.HostedServices
 										KeyPathTemplate = keyTemplate,
 										Type = LegacyDescriptorMetadata.TypeName
 									}),
-									postgresRepo.GetWalletKey(ts.DerivationStrategy).wid));
+									PostgresRepository.GetWalletKey(ts.DerivationStrategy, network).wid));
 							}
 							var wk = postgresRepo.GetWalletKey(keyInfo.TrackedSource);
 							if (processedWalletKeys.Add(wk.wid))

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -28,6 +28,7 @@
     <None Remove="DBScripts\017.FixDoubleSpendDetection.sql" />
     <None Remove="DBScripts\018.FastWalletRecent.sql" />
     <None Remove="DBScripts\020.ReplacingShouldBeIdempotent.sql" />
+    <None Remove="DBScripts\022.WalletsWalletsParentIdIndex.sql" />
   </ItemGroup>
   <ItemGroup>
 	<EmbeddedResource Include="DBScripts\*.sql" />

--- a/NBXplorer/TrackedTransaction.cs
+++ b/NBXplorer/TrackedTransaction.cs
@@ -151,7 +151,7 @@ namespace NBXplorer
 												   Output: o,
 												   KeyPath: KnownKeyPathMapping.TryGet(o.TxOut.ScriptPubKey),
 												   Address: KnownKeyPathInformation.TryGet(o.TxOut.ScriptPubKey)?.Address))
-							.Where(o => o.KeyPath != null || o.Output.TxOut.ScriptPubKey == (TrackedSource as IDestination)?.ScriptPubKey || TrackedSource is WalletTrackedSource)
+							.Where(o => o.KeyPath != null || o.Output.TxOut.ScriptPubKey == (TrackedSource as IDestination)?.ScriptPubKey || TrackedSource is GroupTrackedSource)
 							.Select(o => new MatchedOutput()
 							{
 								Index = o.Index,


### PR DESCRIPTION
Supersede https://github.com/dgarage/NBXplorer/pull/450
This add a new type of tracked source `GroupTrackedSource`.

You can create a group and add other tracked sources as children to it.

Any addresses generated by a child will be added automatically to the group.
Removing a children also remove its addresses from the group.

On top of this, I added an API to add addresses directly to a group via `/cryptos/{cryptoCode}/groups/{groupId}/addresses` API.

Some routes for group API need to be accessed through `/cryptos` and others directly through `/groups`.

Last, I removed abstraction of tracked-sources in the routes of NBXplorer. This is due to the fact that many routes doesn't make sense for all the tracked-sources. (For example CreatePSBT depends on the ability to be able to generate addresses, which a group doesn't have)
