### PR TITLE
Add HasSpendMatch to NewTransactionEvent

### DIFF
--- a/NBXplorer.Client/Models/NewTransactionEvent.cs
+++ b/NBXplorer.Client/Models/NewTransactionEvent.cs
@@ -33,6 +33,11 @@ namespace NBXplorer.Models
 			get; set;
 		} = new List<MatchedOutput>();
 
+		public bool HasSpendMatch
+		{
+			get; set;
+		} = false;
+
 		[JsonIgnore]
 		public override string EventType => "newtransaction";
 

--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -503,6 +503,7 @@ namespace NBXplorer.Backend
 							TransactionHash = matches[i].TransactionHash
 						},
 						Outputs = matches[i].GetReceivedOutputs().ToList(),
+						HasSpendMatch = matches[i].SpentOutpoints.Count != 0,
 						Replacing = matches[i].Replacing.ToList()
 					};
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -626,6 +626,7 @@ Then you will receive such notifications when a transaction is impacting the `de
         "value": 100000000
       }
     ],
+    "hasSpendMatch": false,
     "cryptoCode": "BTC",
     "replacing": ["25d6bc1b2812670550aca8b2984670203b5ebf00e75f9b2bbf1940c3fa27841e", "81a20eb55ec16b92c65d4e142278fd521caa9e5dcad9d941c8e256dbd917ae84"]
   }
@@ -879,6 +880,7 @@ The smallest `eventId` is 1.
           "value": 100000000
         }
       ],
+      "hasSpendMatch": false,
       "cryptoCode": "BTC",
     }
   }


### PR DESCRIPTION
## Problem

We would like to know if a newtransaction event spends any outpoints from the same wallet.

## Solution

Add a new bool to NewTransactionEvent that is true only when SpentOutpoints is not empty.