### PR TITLE
Add MatchedInputs to events

### DIFF
--- a/NBXplorer.Client/Models/NewTransactionEvent.cs
+++ b/NBXplorer.Client/Models/NewTransactionEvent.cs
@@ -28,6 +28,10 @@ namespace NBXplorer.Models
 			get; set;
 		}
 
+		public List<MatchedInput> Inputs
+		{
+			get; set;
+		} = new List<MatchedInput>();
 		public List<MatchedOutput> Outputs
 		{
 			get; set;
@@ -69,5 +73,9 @@ namespace NBXplorer.Models
 	public class MatchedInput : MatchedOutput
 	{
 		public int InputIndex { get; set; }
+		public uint256 TransactionId
+		{
+			get; set;
+		}
 	}
 }

--- a/NBXplorer.Client/NBXplorer.Client.csproj
+++ b/NBXplorer.Client/NBXplorer.Client.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.1</TargetFrameworks>
 		<Company>Digital Garage</Company>
-		<Version>4.3.1</Version>
+		<Version>4.3.2</Version>
 		<Copyright>Copyright © Digital Garage 2017</Copyright>
 		<Description>Client API for the minimalist HD Wallet Tracker NBXplorer</Description>
 		<PackageIcon>Bitcoin.png</PackageIcon>

--- a/NBXplorer/AnnotatedTransactionCollection.cs
+++ b/NBXplorer/AnnotatedTransactionCollection.cs
@@ -39,13 +39,6 @@ namespace NBXplorer
 		{
 			_TxById = new Dictionary<uint256, AnnotatedTransaction>(transactions.Count);
 			ConfirmedTransactions = new List<AnnotatedTransaction>(transactions.Count);
-			foreach (var tx in transactions)
-			{
-				foreach (var keyPathInfo in tx.KnownKeyPathMapping)
-				{
-					_KeyPaths.TryAdd(keyPathInfo.Key, keyPathInfo.Value);
-				}
-			}
 
 			// Let's remove the dups and let's get the current height of the transactions
 			foreach (var trackedTx in transactions)
@@ -259,37 +252,6 @@ namespace NBXplorer
 					return annotatedTransaction.Height < conflicted.Height; // The most buried block win (should never happen though)
 				}
 			}
-		}
-
-		public MatchedOutput GetUTXO(OutPoint outpoint)
-		{
-			if (_TxById.TryGetValue(outpoint.Hash, out var tx))
-			{
-				return tx.Record.GetReceivedOutputs().FirstOrDefault(c => c.Index == outpoint.N);
-			}
-			return null;
-		}
-		public MatchedInput GetSpentUTXO(OutPoint outpoint, int inputIndex)
-		{
-			if (GetUTXO(outpoint) is { } result)
-			{
-				return new MatchedInput()
-				{
-					InputIndex = inputIndex,
-					Index = result.Index,
-					Value = result.Value,
-					KeyPath = result.KeyPath,
-					ScriptPubKey = result.ScriptPubKey
-				};
-			}
-
-			return null;
-		}
-
-		Dictionary<Script, KeyPath> _KeyPaths = new Dictionary<Script, KeyPath>();
-		public KeyPath GetKeyPath(Script scriptPubkey)
-		{
-			return _KeyPaths.TryGet(scriptPubkey);
 		}
 
 		Dictionary<uint256, AnnotatedTransaction> _TxById = new Dictionary<uint256, AnnotatedTransaction>();

--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -502,6 +502,7 @@ namespace NBXplorer.Backend
 							Transaction = matches[i].Transaction,
 							TransactionHash = matches[i].TransactionHash
 						},
+						Inputs = matches[i].MatchedInputs.OrderBy(m => m.InputIndex).ToList(),
 						Outputs = matches[i].GetReceivedOutputs().ToList(),
 						Replacing = matches[i].Replacing.ToList()
 					};

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -569,7 +569,7 @@ namespace NBXplorer.Controllers
 						Transaction = includeTransaction ? tx.Record.Transaction : null,
 						Confirmations = tx.Height.HasValue ? currentHeight - tx.Height.Value + 1 : 0,
 						Timestamp = tx.Record.FirstSeen,
-						Inputs = tx.Record.SpentOutpoints.Select(o =>txs.GetSpentUTXO(o.Outpoint, o.InputIndex)).Where(o => o != null).ToList(),
+						Inputs = tx.Record.MatchedInputs.OrderBy(m => m.InputIndex).ToList(),
 						Outputs = tx.Record.GetReceivedOutputs().ToList(),
 						Replaceable = tx.Replaceable,
 						ReplacedBy = tx.ReplacedBy == NBXplorerNetwork.UnknownTxId ? null : tx.ReplacedBy,

--- a/NBXplorer/MultiDictionary.cs
+++ b/NBXplorer/MultiDictionary.cs
@@ -398,6 +398,13 @@ namespace NBXplorer
 			return new Enumerator(this);
 		}
 
+		public IEnumerable<TValue> GetOrEmpty(TKey key)
+		{
+			if (dictionary.TryGetValue(key, out var v))
+				return v;
+			return Array.Empty<TValue>();
+		}
+
 		#endregion
 
 		/// <summary>

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFramework>
-    <Version>2.5.4</Version>
+    <Version>2.5.5</Version>
 	  <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\NBXplorer.xml</DocumentationFile>
 	  <NoWarn>1701;1702;1705;1591;CS1591</NoWarn>
 	  <LangVersion>12</LangVersion>

--- a/NBXplorer/TrackedTransaction.cs
+++ b/NBXplorer/TrackedTransaction.cs
@@ -148,7 +148,7 @@ namespace NBXplorer
 		public long? BlockHeight { get; set; }
 		public bool Immature { get; internal set; }
 		public HashSet<uint256> Replacing { get; internal set; }
-
+		public List<MatchedInput> MatchedInputs { get; private set; } = new List<MatchedInput>();
 		public IEnumerable<MatchedOutput> GetReceivedOutputs()
 		{
 			return this.ReceivedCoins
@@ -174,6 +174,18 @@ namespace NBXplorer
 			if (keyInfo.Address != null)
 				this.KnownAddresses.TryAdd(keyInfo.ScriptPubKey, keyInfo.Address);
 			this.OwnedScripts.Add(keyInfo.ScriptPubKey);
+		}
+
+		public void UpdateMatchedInputs(IEnumerable<MatchedInput> matchedInputs)
+		{
+			MatchedInputs = new List<MatchedInput>(matchedInputs);
+			foreach (var mi in MatchedInputs)
+			{
+				if (this.KnownAddresses.TryGetValue(mi.ScriptPubKey, out var addr))
+					mi.Address = addr;
+				if (this.KnownKeyPathMapping.TryGetValue(mi.ScriptPubKey, out var keypath))
+					mi.KeyPath = keypath;
+			}
 		}
 	}
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -211,7 +211,24 @@ Returns:
             "value": 100000000
           }
         ],
-        "inputs": [],
+        "inputs": [
+            {
+              "inputIndex": 0,
+              "transactionId": "194d6dc4e1c4c983b5235ad2b82cc7c48c36def4960fdcf37697253c9d9854a2",
+              "scriptPubKey": "001409249118830af97a029217f3a8744973c5a4a02e",
+              "index": 4,
+              "value": 90000000,
+              "address": "bcrt1qpyjfzxyrptuh5q5jzle6sazfw0z6fgpwuz2rye"
+            },
+            {
+              "inputIndex": 1,
+              "transactionId": "194d6dc4e1c4c983b5235ad2b82cc7c48c36def4960fdcf37697253c9d9854a2",
+              "scriptPubKey": "0014d83837bd474d799ad4decba4bac561a7356e0371",
+              "index": 1,
+              "value": 50000000,
+              "address": "bcrt1qmqur0028f4ue44x7ewjt43tp5u6kuqm3eqa3ua"
+            }
+        ],
         "timestamp": 1540381888,
         "balanceChange": 100000000,
         "replaceable": false,
@@ -616,6 +633,23 @@ Then you will receive such notifications when a transaction is impacting the `de
       "height": null,
       "timestamp": 1540434424
     },
+    "inputs": [
+    {
+      "inputIndex": 0,
+      "transactionId": "194d6dc4e1c4c983b5235ad2b82cc7c48c36def4960fdcf37697253c9d9854a2",
+      "scriptPubKey": "001409249118830af97a029217f3a8744973c5a4a02e",
+      "index": 4,
+      "value": 90000000,
+      "address": "bcrt1qpyjfzxyrptuh5q5jzle6sazfw0z6fgpwuz2rye"
+    },
+    {
+      "inputIndex": 1,
+      "transactionId": "194d6dc4e1c4c983b5235ad2b82cc7c48c36def4960fdcf37697253c9d9854a2",
+      "scriptPubKey": "0014d83837bd474d799ad4decba4bac561a7356e0371",
+      "index": 1,
+      "value": 50000000,
+      "address": "bcrt1qmqur0028f4ue44x7ewjt43tp5u6kuqm3eqa3ua"
+    }],
     "outputs": [
       {
         "keyPath": "0/1",


### PR DESCRIPTION
This supersede https://github.com/dgarage/NBXplorer/pull/468 by just adding the matched inputs to the event.

This also add the property `TransactionId` to matched input which strangely wasn't here before.