### PR TITLE
[FIX] Ignore check localhost to whitelist on Bitcoin Core

### DIFF
--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -328,8 +328,16 @@ namespace NBXplorer.Backend
 				else
 				{
 					var addressStr = peer.Address is IPEndPoint end ? end.Address.ToString() : peer.Address?.ToString();
-					Logger.LogWarning($"{Network.CryptoCode}: Your NBXplorer server is not whitelisted by your node," +
-						$" you should add \"whitelist={addressStr}\" to the configuration file of your node. (Or use whitebind)");
+
+					if (addressStr == "127.0.0.1" || addressStr == "::1")
+					{
+						Logger.LogInformation($"Connection is from localhost, no whitelist needed.");
+					}
+					else 
+					{
+						Logger.LogWarning($"{Network.CryptoCode}: Your NBXplorer server is not whitelisted by your node," +
+						    $" you should add \"whitelist={addressStr}\" to the configuration file of your node. (Or use whitebind)");
+					}
 				}
 
 				int waitTime = 10;


### PR DESCRIPTION
Local connections (localhost) do not need to be explicitly whitelisted, as connections from 127.0.0.1 are always allowed without restriction by the Bitcoin node.

This PR fixes the code to avoid the localhost is not whitelisted notice on your node