### PR TITLE
Fix timeout errors, Fix NBXplorer hanging when exiting

### DIFF
--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -420,7 +420,7 @@ namespace NBXplorer.Backend
 		private async Task<BlockLocator> GetDefaultCurrentLocation(CancellationToken token)
 		{
 			if (ChainConfiguration.StartHeight > BlockchainInfo.Headers)
-				throw new InvalidOperationException($"{Network.CryptoCode}: StartHeight should not be above the current tip");
+				throw new InvalidOperationException($"{Network.CryptoCode}: StartHeight ({ChainConfiguration.StartHeight}) should not be above the current tip ({BlockchainInfo.Headers})");
 			BlockLocator blockLocator = null;
 			if (ChainConfiguration.StartHeight == -1)
 			{
@@ -464,7 +464,7 @@ namespace NBXplorer.Backend
 			{
 				await conn.NewBlock(slimChainedBlock);
 			}
-			var matches = await Repository.GetMatches(conn, transactions, slimChainedBlock, now, blockMatch: true, useCache: true);
+			var matches = await Repository.GetMatches(conn, transactions, slimChainedBlock, now, useCache: true, cancellationToken: cts.Token);
 			_ = AddressPoolService.GenerateAddresses(Network, matches);
 
 			long confirmations = 0;

--- a/NBXplorer/HostedServices/RefreshWalletHistoryPeriodicTask.cs
+++ b/NBXplorer/HostedServices/RefreshWalletHistoryPeriodicTask.cs
@@ -27,7 +27,11 @@ namespace NBXplorer.HostedServices
 		public async Task Do(CancellationToken cancellationToken)
 		{
 			await using var conn = await _DS.ReliableOpenConnectionAsync();
-			await conn.ExecuteAsync("SELECT wallets_history_refresh();");
+			var command = new CommandDefinition(
+				commandText: "SELECT wallets_history_refresh();",
+				commandType: System.Data.CommandType.Text,
+				cancellationToken: cancellationToken);
+			await conn.ExecuteAsync(command);
 		}
 
 		public ValueTask DisposeAsync()


### PR DESCRIPTION
Some TimeoutException would show up if a block were taking too much time to process.

This can happen when the node is starting as the cache of non-matching transactions is almost empty. This fix it by increasing the command timeout by 3. (30 sec to 90sec)

On top of this, I noticed NBXplorer were taking a long time to restart. This was caused by the cancellation token weren't passed properly to the SQL queries.