### PR TITLE
Fix: Taproot PSBT's outputs were not including internal key and taproot hd information

### DIFF
--- a/NBXplorer/Controllers/MainController.PSBT.cs
+++ b/NBXplorer/Controllers/MainController.PSBT.cs
@@ -450,21 +450,22 @@ namespace NBXplorer.Controllers
 				// * HDTaprootKeyPaths is used instead of HDKeyPaths
 				// * TaprootSighashType is explicitely set to default
 				// * Fill up TaprootInternalKey
-				foreach (var input in update.PSBT.Inputs)
+				foreach (var c in update.PSBT.Inputs.OfType<PSBTCoin>().Concat(update.PSBT.Outputs))
 				{
-					input.TaprootSighashType = TaprootSigHash.Default;
-					if (input.HDKeyPaths.Count != 1)
+					if (c is PSBTInput input)
+						input.TaprootSighashType = TaprootSigHash.Default;
+					if (c.HDKeyPaths.Count != 1)
 						continue;
-					foreach (var keypath in input.HDKeyPaths)
+					foreach (var keypath in c.HDKeyPaths)
 					{
 						var taprootPubKey = keypath.Key.GetTaprootFullPubKey();
-						input.TaprootInternalKey = taprootPubKey.InternalKey;
+						c.TaprootInternalKey = taprootPubKey.InternalKey;
 						// Some consumers expect the internal key to be in the HDTaprootKeyPaths
-						if (!TaprootPubKey.TryCreate(input.TaprootInternalKey.ToBytes(), out var pk))
+						if (!TaprootPubKey.TryCreate(c.TaprootInternalKey.ToBytes(), out var pk))
 							continue;
-						input.HDTaprootKeyPaths.AddOrReplace(pk, new TaprootKeyPath(keypath.Value));
+						c.HDTaprootKeyPaths.AddOrReplace(pk, new TaprootKeyPath(keypath.Value));
 					}
-					input.HDKeyPaths.Clear();
+					c.HDKeyPaths.Clear();
 				}
 			}
 		}

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net8.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFramework>
-    <Version>2.5.15</Version>
+    <Version>2.5.16</Version>
 	  <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\NBXplorer.xml</DocumentationFile>
 	  <NoWarn>1701;1702;1705;1591;CS1591</NoWarn>
 	  <LangVersion>12</LangVersion>


### PR DESCRIPTION
Taproot outputs belonging to the wallet weren't properly including `PSBT_OUT_TAP_BIP32_DERIVATION ` and internal key.

https://github.com/btcpayserver/btcpayserver/issues/5715