### PR TITLE
New route for subscribing to events via websockets

### DIFF
--- a/NBXplorer.Client/ExplorerClient.cs
+++ b/NBXplorer.Client/ExplorerClient.cs
@@ -229,6 +229,17 @@ namespace NBXplorer
 			await session.ConnectAsync(cancellation).ConfigureAwait(false);
 			return session;
 		}
+		public WebsocketNotificationSessionLegacy CreateWebsocketNotificationSessionLegacy(CancellationToken cancellation = default)
+		{
+			return CreateWebsocketNotificationSessionLegacyAsync(cancellation).GetAwaiter().GetResult();
+		}
+
+		public async Task<WebsocketNotificationSessionLegacy> CreateWebsocketNotificationSessionLegacyAsync(CancellationToken cancellation = default)
+		{
+			var session = new WebsocketNotificationSessionLegacy(this);
+			await session.ConnectAsync(cancellation).ConfigureAwait(false);
+			return session;
+		}
 
 		public UTXOChanges GetUTXOs(TrackedSource trackedSource, CancellationToken cancellation = default)
 		{

--- a/NBXplorer.Client/WebsocketNotificationSession.cs
+++ b/NBXplorer.Client/WebsocketNotificationSession.cs
@@ -7,71 +7,16 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin.Protocol;
 
 namespace NBXplorer
 {
-	public class WebsocketNotificationSession : NotificationSessionBase, IDisposable
+	public class WebsocketNotificationSessionLegacy : WebsocketNotificationSession
 	{
-
-		private readonly ExplorerClient _Client;
-		public ExplorerClient Client
+		protected override FormattableString GetConnectPath() => $"v1/cryptos/{_Client.CryptoCode}/connect";
+		internal WebsocketNotificationSessionLegacy(ExplorerClient client) : base(client)
 		{
-			get
-			{
-				return _Client;
-			}
 		}
-		internal WebsocketNotificationSession(ExplorerClient client)
-		{
-			if(client == null)
-				throw new ArgumentNullException(nameof(client));
-			_Client = client;
-		}
-
-		internal async Task ConnectAsync(CancellationToken cancellation)
-		{
-			var uri = _Client.GetFullUri($"v1/cryptos/{_Client.CryptoCode}/connect");
-			uri = ToWebsocketUri(uri);
-			WebSocket socket = null;
-			try
-			{
-				socket = await ConnectAsyncCore(uri, cancellation);
-			}
-			catch(WebSocketException) // For some reason the ErrorCode is not properly set, so we can check for error 401
-			{
-				if(!_Client.Auth.RefreshCache())
-					throw;
-				socket = await ConnectAsyncCore(uri, cancellation);
-			}
-			JsonSerializerSettings settings = new JsonSerializerSettings();
-			new Serializer(_Client.Network).ConfigureSerializer(settings);
-			_MessageListener = new WebsocketMessageListener(socket, settings);
-		}
-
-		private async Task<ClientWebSocket> ConnectAsyncCore(string uri, CancellationToken cancellation)
-		{
-			var socket = new ClientWebSocket();
-			_Client.Auth.SetWebSocketAuth(socket);
-			try
-			{
-				await socket.ConnectAsync(new Uri(uri, UriKind.Absolute), cancellation).ConfigureAwait(false);
-			}
-			catch { socket.Dispose(); throw; }
-			return socket;
-		}
-
-		private static string ToWebsocketUri(string uri)
-		{
-			if(uri.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-				uri = uri.Replace("https://", "wss://");
-			if(uri.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
-				uri = uri.Replace("http://", "ws://");
-			return uri;
-		}
-
-		WebsocketMessageListener _MessageListener;
-		UTF8Encoding UTF8 = new UTF8Encoding(false, true);
-
 		public void ListenNewBlock(CancellationToken cancellation = default)
 		{
 			ListenNewBlockAsync(cancellation).GetAwaiter().GetResult();
@@ -128,7 +73,7 @@ namespace NBXplorer
 
 		public Task ListenDerivationSchemesAsync(DerivationStrategyBase[] derivationSchemes, CancellationToken cancellation = default)
 		{
-			return _MessageListener.Send(new Models.NewTransactionEventRequest() { DerivationSchemes = derivationSchemes.Select(d=>d.ToString()).ToArray(), CryptoCode = _Client.CryptoCode }, null, cancellation);
+			return _MessageListener.Send(new Models.NewTransactionEventRequest() { DerivationSchemes = derivationSchemes.Select(d => d.ToString()).ToArray(), CryptoCode = _Client.CryptoCode }, null, cancellation);
 		}
 
 		public void ListenTrackedSources(TrackedSource[] trackedSources, CancellationToken cancellation = default)
@@ -140,6 +85,70 @@ namespace NBXplorer
 		{
 			return _MessageListener.Send(new Models.NewTransactionEventRequest() { TrackedSources = trackedSources.Select(d => d.ToString()).ToArray(), CryptoCode = _Client.CryptoCode }, null, cancellation);
 		}
+
+	}
+	public class WebsocketNotificationSession : NotificationSessionBase, IDisposable
+	{
+
+		protected readonly ExplorerClient _Client;
+		public ExplorerClient Client
+		{
+			get
+			{
+				return _Client;
+			}
+		}
+		internal WebsocketNotificationSession(ExplorerClient client)
+		{
+			if(client == null)
+				throw new ArgumentNullException(nameof(client));
+			_Client = client;
+		}
+
+		internal async Task ConnectAsync(CancellationToken cancellation)
+		{
+			var uri = _Client.GetFullUri(GetConnectPath());
+			uri = ToWebsocketUri(uri);
+			WebSocket socket = null;
+			try
+			{
+				socket = await ConnectAsyncCore(uri, cancellation);
+			}
+			catch (WebSocketException) // For some reason the ErrorCode is not properly set, so we can check for error 401
+			{
+				if (!_Client.Auth.RefreshCache())
+					throw;
+				socket = await ConnectAsyncCore(uri, cancellation);
+			}
+			JsonSerializerSettings settings = new JsonSerializerSettings();
+			new Serializer(_Client.Network).ConfigureSerializer(settings);
+			_MessageListener = new WebsocketMessageListener(socket, settings);
+		}
+
+		protected virtual FormattableString GetConnectPath() => $"v1/cryptos/connect?cryptoCode={_Client.Network.CryptoCode}";
+
+		private async Task<ClientWebSocket> ConnectAsyncCore(string uri, CancellationToken cancellation)
+		{
+			var socket = new ClientWebSocket();
+			_Client.Auth.SetWebSocketAuth(socket);
+			try
+			{
+				await socket.ConnectAsync(new Uri(uri, UriKind.Absolute), cancellation).ConfigureAwait(false);
+			}
+			catch { socket.Dispose(); throw; }
+			return socket;
+		}
+
+		private static string ToWebsocketUri(string uri)
+		{
+			if(uri.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+				uri = uri.Replace("https://", "wss://");
+			if(uri.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+				uri = uri.Replace("http://", "ws://");
+			return uri;
+		}
+
+		protected WebsocketMessageListener _MessageListener;
 
 		public override Task<NewEventBase> NextEventAsync(CancellationToken cancellation = default)
 		{

--- a/NBXplorer/ListenEventsRequest.cs
+++ b/NBXplorer/ListenEventsRequest.cs
@@ -1,0 +1,27 @@
+﻿namespace NBXplorer;
+
+
+public class ListenEventsRequest
+{
+	public enum RuleAction
+	{
+		Allow,
+		Reject
+	}
+	public class ListenRule
+	{
+		public enum EventType
+		{
+			NewBlock,
+			NewTransaction
+		}
+		public string CryptoCode { get; set; }
+		public bool Inverse { get; set; }
+		public EventType? Type { get; set; }
+		public RuleAction Action { get; set; }
+		public string TrackedSource { get; set; }
+		public string DerivationScheme { get; set; }
+	}
+	public ListenRule[] Rules { get; set; }
+	public RuleAction DefaultAction { get; set; }
+}

--- a/NBXplorer/wwwroot/api.json
+++ b/NBXplorer/wwwroot/api.json
@@ -2307,7 +2307,7 @@
         }
       }
     },
-    "/v1/cryptos/{cryptoCode}/connect": {
+    "/v1/cryptos/connect": {
       "get": {
         "summary": "WebSocket connection for events",
         "operationId": "WebSocket",
@@ -2317,7 +2317,14 @@
         ],
         "parameters": [
           {
-            "$ref": "#/components/parameters/CryptoCode"
+            "name": "cryptoCode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BTC",
+            "description": "Filter event for this cryptoCode. If unspecified or `*`, all events will be published to this websocket."
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR resolves #460.

It also add a new route to subscribe to events via web sockets.

After migrating the API documentation to [ReDoc](https://dgarage.github.io/NBXplorer/), the instructions for subscribing to events via the web socket were no longer included.

Unfortunately, OpenAPI is designed exclusively for REST APIs and does not support documenting web socket protocols.

To address this, we have introduced a new web socket route: `cryptos/connect?cryptoCode=?` (where `cryptoCode` is optional). This route ensures the web socket receives all events, which aligns with the typical use case for most users.

For users who prefer to receive fewer events from the server, the previous API remain documented and available in an [older version of API.md](https://github.com/dgarage/NBXplorer/blob/22b8e0b17af4bfc78c6dda3811e706ec13f79ab5/docs/API.md). Alternatively, users can implement client-side filtering.