### PR TITLE
Save and expose to the API fee information about transactions when available

### DIFF
--- a/NBXplorer.Client/Models/GetTransactionsResponse.cs
+++ b/NBXplorer.Client/Models/GetTransactionsResponse.cs
@@ -106,5 +106,6 @@ namespace NBXplorer.Models
 		public uint256 ReplacedBy { get; set; }
 		public uint256 Replacing { get; set; }
 		public bool Replaceable { get; set; }
+		public TransactionMetadata Metadata { get; set; }
 	}
 }

--- a/NBXplorer.Client/Models/TransactionMetadata.cs
+++ b/NBXplorer.Client/Models/TransactionMetadata.cs
@@ -1,0 +1,28 @@
+﻿using NBitcoin;
+using NBitcoin.JsonConverters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NBXplorer.Models
+{
+	public class TransactionMetadata
+	{
+		[JsonProperty("vsize", DefaultValueHandling = DefaultValueHandling.Ignore)]
+		public int? VirtualSize { get; set; }
+		[JsonProperty("fees", DefaultValueHandling = DefaultValueHandling.Ignore)]
+		[JsonConverter(typeof(NBXplorer.JsonConverters.MoneyJsonConverter))]
+		public Money Fees { get; set; }
+		[JsonProperty("feeRate", DefaultValueHandling = DefaultValueHandling.Ignore)]
+		[JsonConverter(typeof(NBitcoin.JsonConverters.FeeRateJsonConverter))]
+		public FeeRate FeeRate { get; set; }
+		public static TransactionMetadata Parse(string json) => JsonConvert.DeserializeObject<TransactionMetadata>(json);
+		public string ToString(bool indented) => JsonConvert.SerializeObject(this, indented ? Formatting.Indented : Formatting.None);
+		public override string ToString() => ToString(true);
+
+		[JsonExtensionData]
+		public IDictionary<string, JToken> AdditionalData { get; set; } = new Dictionary<string, JToken>();
+	}
+}

--- a/NBXplorer.Client/Models/TransactionResult.cs
+++ b/NBXplorer.Client/Models/TransactionResult.cs
@@ -55,5 +55,7 @@ namespace NBXplorer.Models
 			set;
 		}
 		public uint256 ReplacedBy { get; set; }
+
+		public TransactionMetadata Metadata { get; set; }
 	}
 }

--- a/NBXplorer.Tests/ServerTester.cs
+++ b/NBXplorer.Tests/ServerTester.cs
@@ -206,7 +206,6 @@ namespace NBXplorer.Tests
 		public HttpClient HttpClient { get; internal set; }
 
 		string datadir;
-
 		public void ResetExplorer(bool deleteAll = true)
 		{
 			Host.Dispose();

--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -503,7 +503,8 @@ namespace NBXplorer.Backend
 							Confirmations = confirmations,
 							Timestamp = now,
 							Transaction = matches[i].Transaction,
-							TransactionHash = matches[i].TransactionHash
+							TransactionHash = matches[i].TransactionHash,
+							Metadata = matches[i].Metadata
 						},
 						Inputs = matches[i].MatchedInputs,
 						Outputs = matches[i].MatchedOutputs,

--- a/NBXplorer/Backend/SavedTransaction.cs
+++ b/NBXplorer/Backend/SavedTransaction.cs
@@ -1,4 +1,5 @@
 ﻿using NBitcoin;
+using NBXplorer.Models;
 using System;
 
 namespace NBXplorer.Backend
@@ -23,5 +24,7 @@ namespace NBXplorer.Backend
 			set;
 		}
 		public uint256 ReplacedBy { get; set; }
+
+		public TransactionMetadata Metadata { get; set; }
 	}
 }

--- a/NBXplorer/Controllers/MainController.PSBT.cs
+++ b/NBXplorer/Controllers/MainController.PSBT.cs
@@ -584,8 +584,8 @@ namespace NBXplorer.Controllers
 								// If this is not segwit, or we are unsure of it, let's try to grab from our saved transactions
 								if (input.NonWitnessUtxo == null)
 								{
-									var prev = await repo.GetSavedTransactions(input.PrevOut.Hash);
-									if (prev.FirstOrDefault() is SavedTransaction saved)
+									var prev = await repo.GetSavedTransaction(input.PrevOut.Hash);
+									if (prev is SavedTransaction saved)
 									{
 										input.NonWitnessUtxo = saved.Transaction;
 									}

--- a/NBXplorer/TrackedTransaction.cs
+++ b/NBXplorer/TrackedTransaction.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using NBitcoin;
 using NBXplorer.Models;
+using Newtonsoft.Json.Linq;
 using static NBXplorer.Backend.DbConnectionHelper;
 
 namespace NBXplorer
@@ -146,15 +147,10 @@ namespace NBXplorer
 		}
 
 		public IEnumerable<MatchedOutput> InOuts => MatchedInputs.Concat(MatchedOutputs);
+
+		public TransactionMetadata Metadata { get; set; }
 	}
 
 
-	public record TrackedTransactionKey(uint256 TxId, uint256 BlockHash, bool IsPruned)
-	{
-		public override string ToString()
-		{
-			var prunedSuffix = IsPruned ? ":P" : string.Empty;
-			return $"{TxId}:{BlockHash}{prunedSuffix}";
-		}
-	}
+	public record TrackedTransactionKey(uint256 TxId, uint256 BlockHash, bool IsPruned);
 }

--- a/NBXplorer/Utils.cs
+++ b/NBXplorer/Utils.cs
@@ -108,20 +108,17 @@ namespace NBXplorer
 			return result;
 		}
 
-		public static TransactionResult ToTransactionResult(long height, SavedTransaction[] result)
-		{
-			var noDate = NBitcoin.Utils.UnixTimeToDateTime(0);
-			var oldest = result
-						.Where(o => o.Timestamp != noDate)
-						.OrderBy(o => o.Timestamp).FirstOrDefault() ?? result.First();
-
-			var confBlock = result
-					 .Select(r => (r.BlockHash, r.BlockHeight))
-					 .FirstOrDefault(r => r.BlockHeight.HasValue);
-
-			var conf = confBlock.BlockHash is null ? 0 : height - confBlock.BlockHeight.Value + 1;
-
-			return new TransactionResult() { Confirmations = conf, BlockId = confBlock.BlockHash, Transaction = oldest.Transaction, TransactionHash = oldest.Transaction.GetHash(), Height = confBlock.BlockHeight, Timestamp = oldest.Timestamp, ReplacedBy = oldest.ReplacedBy };
-		}
+		public static TransactionResult ToTransactionResult(long height, SavedTransaction result)
+		=> new TransactionResult()
+			{
+				Confirmations = result.BlockHeight is long bh ? height - bh + 1 : 0,
+				BlockId = result.BlockHash,
+				Transaction = result.Transaction,
+				TransactionHash = result.Transaction.GetHash(),
+				Height = result.BlockHeight,
+				Timestamp = result.Timestamp,
+				ReplacedBy = result.ReplacedBy,
+				Metadata = result.Metadata
+			};
 	}
 }

--- a/NBXplorer/wwwroot/api.json
+++ b/NBXplorer/wwwroot/api.json
@@ -85,11 +85,82 @@
           }
         }
       },
+      "TransactionMetadata": {
+        "type": "object",
+        "description": "Additional metadata related to the transaction. This may be null if the transaction had been indexed when it wasn't in the mempool anymore.'",
+        "nullable": true,
+        "properties": {
+          "vsize": {
+            "type": "integer",
+            "description": "Virtual size of the transaction. Only available if the transaction has been indexed when it was in the mempool.",
+            "example": 141,
+            "nullable": true
+          },
+          "fees": {
+            "type": "integer",
+            "description": "Total fee of this transaction in satoshi. Only available if the transaction has been indexed when it was in the mempool.",
+            "example": 2820,
+            "nullable": true
+          },
+          "feeRate": {
+            "type": "number",
+            "description": "The estimated fee rate in satoshis per vByte. Only available if the transaction has been indexed when it was in the mempool.",
+            "example": 20.0,
+            "nullable": true
+          }
+        }
+      },
+      "TransactionResult": {
+        "type": "object",
+        "properties": {
+          "blockHash": {
+            "type": "string",
+            "example": "7639350b31f3ce07ff976ebae772fef1602b30a10ccb8ca69047fe0fe8b9083c",
+            "description": "The hash of the block containing this transaction. Will be `null` if the transaction is unconfirmed."
+          },
+          "confirmations": {
+            "type": "integer",
+            "description": "Number of confirmations the transaction has.",
+            "example": 1
+          },
+          "height": {
+            "type": "integer",
+            "description": "The block height. Will be `null` if the transaction is unconfirmed.",
+            "example": 876593
+          },
+          "transactionId": {
+            "type": "string",
+            "description": "The transaction ID.",
+            "example": "14a679cd743f3d2aa51b998747c58dfa9b31c8c669006fc6c6efe4b4f5f76e5b"
+          },
+          "transaction": {
+            "type": "string",
+            "description": "Raw transaction in hex format. Included only if `includeTransaction` is `true`.",
+            "example": "02000000000101b596e23a22ea753251a5da4b7d415604dc05ab7c45ff675e077ed60a0d0a8d277401000000fdffffff0126010000000000001600140e48fd70dbb5af35119bfe7d626944c48c98ed9d0340e6c77a58ede14930d83002f05b8a13320a4140ab40a45b7f677f05c7653479d62b3d121823503563096156429b8fe5d818381812b4854ed3f59ec999b6fca8a94420afd36e561af10735e88f95d9655e5b3f7bc79de0a4781ef99d1e030c0c567422ac0063036f7264510a746578742f706c61696e000d3837363537382e6269746d61706821c0afd36e561af10735e88f95d9655e5b3f7bc79de0a4781ef99d1e030c0c56742200000000"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/TransactionMetadata"
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "The UNIX timestamp indicating when the transaction was first seen by NBXplorer.",
+            "example": 1540376171
+          },
+          "replacedBy": {
+            "type": "string",
+            "nullable": true,
+            "example": "8fdac258458f9216b035b30a62ca0400697d76a83f50cd7dc18eb8352e936cf2",
+            "description": "If present, indicates the transaction ID that replaced this transaction via RBF."
+          }
+        }
+      },
+
       "TransactionResponse": {
         "type": "object",
         "properties": {
           "blockHash": {
             "type": "string",
+            "example": "3cdb91b426822f15ad3ca223654db914dc487fa73393532b089689b8e38efbf3",
             "description": "The hash of the block containing this transaction. Will be `null` if the transaction is unconfirmed."
           },
           "confirmations": {
@@ -110,6 +181,9 @@
             "type": "string",
             "description": "Raw transaction in hex format. Included only if `includeTransaction` is `true`.",
             "example": "02000000000101b596e23a22ea753251a5da4b7d415604dc05ab7c45ff675e077ed60a0d0a8d277401000000fdffffff0126010000000000001600140e48fd70dbb5af35119bfe7d626944c48c98ed9d0340e6c77a58ede14930d83002f05b8a13320a4140ab40a45b7f677f05c7653479d62b3d121823503563096156429b8fe5d818381812b4854ed3f59ec999b6fca8a94420afd36e561af10735e88f95d9655e5b3f7bc79de0a4781ef99d1e030c0c567422ac0063036f7264510a746578742f706c61696e000d3837363537382e6269746d61706821c0afd36e561af10735e88f95d9655e5b3f7bc79de0a4781ef99d1e030c0c56742200000000"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/TransactionMetadata"
           },
           "outputs": {
             "type": "array",
@@ -146,6 +220,7 @@
           "replacedBy": {
             "type": "string",
             "nullable": true,
+            "example": "8fdac258458f9216b035b30a62ca0400697d76a83f50cd7dc18eb8352e936cf2",
             "description": "If present, indicates the transaction ID that replaced this transaction via RBF."
           }
         }
@@ -747,31 +822,29 @@
         "properties": {
           "height": {
             "type": "integer",
-            "description": "Height of the new block."
+            "description": "Height of the new block.",
+            "example": 104
           },
           "hash": {
             "type": "string",
-            "description": "Hash of the new block."
+            "description": "Hash of the new block.",
+            "example": "1f31c605c0a5d54b65fa39dc8cb4db025be63c66280279ade9338571a9e63d35"
           },
           "previousBlockHash": {
             "type": "string",
-            "description": "Hash of the previous block."
+            "description": "Hash of the previous block.",
+            "example": "7639350b31f3ce07ff976ebae772fef1602b30a10ccb8ca69047fe0fe8b9083c"
           },
           "cryptoCode": {
             "type": "string",
+            "example": "BTC",
             "description": "Cryptocurrency code (e.g., 'BTC')."
           },
           "confirmations": {
             "type": "integer",
-            "description": "Number of confirmations (typically 1 for a new block)."
+            "description": "Number of confirmations (typically 1 for a new block).",
+            "example": 1
           }
-        },
-        "example": {
-          "height": 104,
-          "hash": "1f31c605c0a5d54b65fa39dc8cb4db025be63c66280279ade9338571a9e63d35",
-          "previousBlockHash": "7639350b31f3ce07ff976ebae772fef1602b30a10ccb8ca69047fe0fe8b9083c",
-          "cryptoCode": "BTC",
-          "confirmations": 1
         }
       },
       "NewTransactionEvent": {
@@ -833,7 +906,7 @@
             "description": "The derivation strategy used."
           },
           "transactionData": {
-            "$ref": "#/components/schemas/TransactionResponse"
+            "$ref": "#/components/schemas/TransactionResult"
           },
           "outputs": {
             "type": "array",
@@ -1743,74 +1816,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TransactionResponse"
-                },
-                "examples": {
-                  "withoutTransaction": {
-                    "summary": "Without raw transaction data",
-                    "value": {
-                      "blockHash": "0000000000000000000...",
-                      "confirmations": 3,
-                      "height": 600000,
-                      "transactionId": "abcd1234...",
-                      "outputs": [
-                        {
-                          "scriptPubKey": "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac",
-                          "index": 0,
-                          "value": 5000000000,
-                          "keyPath": "0/0"
-                        }
-                      ],
-                      "inputs": [
-                        {
-                          "inputIndex": 0,
-                          "transactionId": "efgh5678...",
-                          "index": 1,
-                          "scriptPubKey": "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac",
-                          "value": 5000000000,
-                          "address": "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
-                        }
-                      ],
-                      "timestamp": 1638307200,
-                      "balanceChange": 0,
-                      "replaceable": false,
-                      "replacing": null,
-                      "replacedBy": null
-                    }
-                  },
-                  "withTransaction": {
-                    "summary": "With raw transaction data",
-                    "value": {
-                      "blockHash": "0000000000000000000...",
-                      "confirmations": 3,
-                      "height": 600000,
-                      "transactionId": "abcd1234...",
-                      "transaction": "0200000001abcd1234...",
-                      "outputs": [
-                        {
-                          "scriptPubKey": "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac",
-                          "index": 0,
-                          "value": 5000000000,
-                          "keyPath": "0/0"
-                        }
-                      ],
-                      "inputs": [
-                        {
-                          "inputIndex": 0,
-                          "transactionId": "efgh5678...",
-                          "index": 1,
-                          "scriptPubKey": "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac",
-                          "value": 5000000000,
-                          "address": "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
-                        }
-                      ],
-                      "timestamp": 1638307200,
-                      "balanceChange": 0,
-                      "replaceable": false,
-                      "replacing": null,
-                      "replacedBy": null
-                    }
-                  }
+                  "$ref": "#/components/schemas/TransactionResult"
                 }
               }
             }


### PR DESCRIPTION
This PR is saving in the `txs.metadata` some useful information such as fee, virtual size and fee rate.

```json
   "metadata": {
    "vsize": 141,
    "fees": 2820,
    "feeRate": 20.0
  }
```

`/v1/cryptos/{cryptoCode}/transactions/{txId}` will now also look into the node's `getrawtransaction` if the data isn't found in the database, regardless of index availability.

I also added `getmempoolentry` to the list of whitelisted RPC methods exposed by NBXplorer.

It also improve a bit performance by not querying database twice when checking for a match, if it is unsuccessful.