### PR TITLE
Get transaction data from peer when possible

### DIFF
--- a/NBXplorer.Client/NBXplorer.Client.csproj
+++ b/NBXplorer.Client/NBXplorer.Client.csproj
@@ -27,8 +27,8 @@
 		  <NoWarn>$(NoWarn);1591;1573;1572;1584;1570;3021</NoWarn>
         </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="NBitcoin" Version="8.0.3" />
-		<PackageReference Include="NBitcoin.Altcoins" Version="4.0.3" />
+		<PackageReference Include="NBitcoin" Version="8.0.4" />
+		<PackageReference Include="NBitcoin.Altcoins" Version="4.0.4" />
 	</ItemGroup>
   <ItemGroup>
 	<None Include="..\README.md" Pack="true" PackagePath="\" />

--- a/NBXplorer.Tests/NBXplorer.Tests.csproj
+++ b/NBXplorer.Tests/NBXplorer.Tests.csproj
@@ -11,7 +11,7 @@
     <EmbeddedResource Include="Scripts\generate-whale.sql" />
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="NBitcoin.TestFramework" Version="3.0.36" />
+      <PackageReference Include="NBitcoin.TestFramework" Version="3.0.37" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 	  <PackageReference Include="xunit" Version="2.9.2" />
 	  <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">

--- a/NBXplorer/Backend/DbConnectionHelper.cs
+++ b/NBXplorer/Backend/DbConnectionHelper.cs
@@ -159,7 +159,7 @@ namespace NBXplorer.Backend
 			List<OutpointRaw> rawOutpoints = new List<OutpointRaw>(outpointCount);
 			foreach (var o in outPoints)
 				rawOutpoints.Add(new OutpointRaw(o.Hash.ToString(), o.N));
-			Dictionary <OutPoint, TxOut> result = new Dictionary<OutPoint, TxOut>();
+			var result = new Dictionary<OutPoint, TxOut>();
 			foreach (var r in await Connection.QueryAsync<(string tx_id, long idx, string script, long value, string asset_id)>(
 				"SELECT o.tx_id, o.idx, o.script, o.value, o.asset_id FROM unnest(@outpoints) outpoints " +
 				"JOIN outs o ON code=@code AND o.tx_id=outpoints.tx_id AND o.idx=outpoints.idx",

--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -303,11 +303,8 @@ namespace NBXplorer.Backend
 				await node.SendMessageAsync(new SendHeadersPayload());
 
 				await RPCArgs.TestRPCAsync(Network, RPCClient, token, Logger);
-				if (await RPCClient.SupportTxIndex() is bool txIndex)
-				{
-					ChainConfiguration.HasTxIndex = txIndex;
-				}
-				if (ChainConfiguration.HasTxIndex)
+				HasTxIndex = await RPCClient.SupportTxIndex() is true;
+				if (HasTxIndex)
 				{
 					Logger.LogInformation($"Has txindex support");
 				}
@@ -616,6 +613,7 @@ namespace NBXplorer.Backend
 		public ChainConfiguration ChainConfiguration { get; }
 		public EventAggregator EventAggregator { get; }
 		public GetBlockchainInfoResponse BlockchainInfo { get; private set; }
+		public bool HasTxIndex { get; private set; }
 
 		NBXplorerNetwork network;
 		private int maxinflight = 10;

--- a/NBXplorer/Backend/SavedTransaction.cs
+++ b/NBXplorer/Backend/SavedTransaction.cs
@@ -6,6 +6,7 @@ namespace NBXplorer.Backend
 {
 	public class SavedTransaction
 	{
+		public uint256 TxId { get; set; }
 		public NBitcoin.Transaction Transaction
 		{
 			get; set;

--- a/NBXplorer/Configuration/ExplorerConfiguration.cs
+++ b/NBXplorer/Configuration/ExplorerConfiguration.cs
@@ -49,7 +49,6 @@ namespace NBXplorer.Configuration
 			set;
 		}
 		public bool NoWarmup { get; set; }
-		public bool HasTxIndex { get; set; }
 		public bool ExposeRPC { get; set; }
 	}
 	public class ExplorerConfiguration

--- a/NBXplorer/Extensions.cs
+++ b/NBXplorer/Extensions.cs
@@ -193,7 +193,7 @@ namespace NBXplorer
 
 			services.TryAddSingleton<CookieRepository>();
 			services.TryAddSingleton<Broadcaster>();
-
+			services.AddSingleton<UTXOFetcherService>();
 			services.AddHostedService<HostedServices.DatabaseSetupHostedService>();
 			services.AddSingleton<IHostedService, RepositoryProvider>(o => o.GetRequiredService<RepositoryProvider>());
 			services.TryAddSingleton<RepositoryProvider, RepositoryProvider>();

--- a/NBXplorer/HostedServices/UTXOFetcherService.cs
+++ b/NBXplorer/HostedServices/UTXOFetcherService.cs
@@ -1,0 +1,177 @@
+﻿#nullable enable
+using NBitcoin;
+using NBitcoin.RPC;
+using NBXplorer.Backend;
+using NBXplorer.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NBXplorer.HostedServices
+{
+	public class UTXOFetcherService
+	{
+		private readonly RepositoryProvider repositoryProvider;
+
+		public Indexers Indexers { get; }
+		public NBXplorerNetworkProvider Networks { get; }
+
+		public UTXOFetcherService(
+			RepositoryProvider repositoryProvider,
+			Indexers indexers,
+			NBXplorerNetworkProvider networks)
+		{
+			this.repositoryProvider = repositoryProvider;
+			Indexers = indexers;
+			Networks = networks;
+		}
+		enum UTXORequirement
+		{
+			WitnessUTXO,
+			Unknown,
+			NonWitnessUTXO,
+			None
+		}
+		static UTXORequirement RequiredUTXO(PSBTInput input, bool alwaysIncludeNonWitnessUTXO)
+		{
+			if (input.IsFinalized() || input.NonWitnessUtxo is not null)
+				return UTXORequirement.None;
+
+			bool? requireNonWitnessUTXO = null;
+			if (alwaysIncludeNonWitnessUTXO)
+				requireNonWitnessUTXO = true;
+			else if (input.PSBT.Network.Consensus.NeverNeedPreviousTxForSigning)
+				requireNonWitnessUTXO = false;
+			else if ((input.GetSignableCoin() ?? input.GetCoin())?.IsMalleable is bool isMalleable)
+				requireNonWitnessUTXO = isMalleable;
+
+			return requireNonWitnessUTXO switch
+			{
+				true => UTXORequirement.NonWitnessUTXO,
+				null => UTXORequirement.Unknown,
+				false when input.WitnessUtxo is null => UTXORequirement.WitnessUTXO,
+				_ => UTXORequirement.None
+			};
+		}
+		public async Task<Dictionary<uint256, Transaction>> FetchTransactions(IEnumerable<uint256> txIds, NBXplorerNetwork network)
+		{
+			var result = new Dictionary<uint256, Transaction>();
+			var dummy = Transaction.Create(network.NBitcoinNetwork);
+			foreach (var txId in txIds)
+				dummy.Inputs.Add(new OutPoint(txId, 0));
+			if (dummy.Inputs.Count == 0)
+				return result;
+			var psbt = PSBT.FromTransaction(dummy, network.NBitcoinNetwork);
+			var update = new UpdatePSBTRequest()
+			{
+				PSBT = psbt,
+				AlwaysIncludeNonWitnessUTXO = true
+			};
+			await UpdateUTXO(update);
+			foreach (var input in update.PSBT.Inputs)
+			{
+				if (input.NonWitnessUtxo is not null)
+					result.TryAdd(input.PrevOut.Hash, input.NonWitnessUtxo);
+			}
+			return result;
+		}
+		public async Task UpdateUTXO(UpdatePSBTRequest update)
+		{
+			var network = Networks.GetFromCryptoCode(update.PSBT.Network.NetworkSet.CryptoCode);
+			if (network is null)
+				return;
+			var indexer = Indexers.GetIndexer(network);
+			if (indexer is null)
+				return;
+			var rpc = indexer.GetConnectedClient();
+			var repo = repositoryProvider.GetRepository(network);
+
+			var inputWithRequirements = update.PSBT.Inputs.Select(txin => (Input: txin, Requirement: RequiredUTXO(txin, update.AlwaysIncludeNonWitnessUTXO))).ToArray();
+			var satifiedInput = inputWithRequirements.Where(r => r.Requirement is UTXORequirement.None).Select(r => r.Input).ToHashSet();
+			var needWitnessUTXO = inputWithRequirements.Where(r => r.Requirement is UTXORequirement.WitnessUTXO or UTXORequirement.Unknown);
+			var utxosByOutpoints = await repo.GetUTXOs(needWitnessUTXO.Select(r => r.Input.PrevOut).ToHashSet());
+			foreach (var r in needWitnessUTXO)
+			{
+				var input = r.Input;
+				if (utxosByOutpoints.TryGetValue(input.PrevOut, out var txout))
+				{
+					input.WitnessUtxo = txout;
+					if (r.Requirement is not UTXORequirement.Unknown ||
+						RequiredUTXO(input, update.AlwaysIncludeNonWitnessUTXO) == UTXORequirement.None)
+						satifiedInput.Add(input);
+				}
+			}
+
+			var unSatisfiedInputs = inputWithRequirements
+									// No .ToArray() on purpose
+									.Where(u => !satifiedInput.Contains(u.Input))
+									.Select(u => u.Input);
+
+			var txByHash = await repo.GetSavedTransactions(Repository.SavedTransactionsQuery.GetMany(unSatisfiedInputs.Select(u => u.PrevOut.Hash).ToHashSet()));
+			foreach (var input in unSatisfiedInputs)
+			{
+				if (txByHash.TryGetValue(input.PrevOut.Hash, out var savedTx) && savedTx.Transaction is not null)
+				{
+					input.NonWitnessUtxo = savedTx.Transaction;
+					satifiedInput.Add(input);
+					txByHash.Remove(input.PrevOut.Hash);
+				}
+			}
+
+			var externallyFetchedTxs = new List<Transaction>();
+			// We check with rpc's txindex
+			if (rpc is not null && indexer.HasTxIndex)
+			{
+				var txByHashes2 = await rpc.GetRawTransactions(unSatisfiedInputs.Select(c => c.PrevOut.Hash).ToHashSet());
+				foreach (var input in unSatisfiedInputs)
+				{
+					if (txByHashes2.TryGetValue(input.PrevOut.Hash, out var savedTx))
+					{
+						input.NonWitnessUtxo = savedTx;
+						externallyFetchedTxs.Add(savedTx);
+						satifiedInput.Add(input);
+						txByHash.Remove(input.PrevOut.Hash);
+					}
+				}
+			}
+
+			var txFetchedFromBlocks = await rpc.GetTransactionFromBlocks(txByHash.Where(t => t.Value.BlockHash is not null).Select(t => (t.Value.BlockHash, t.Value.TxId)).ToHashSet());
+			foreach (var input in unSatisfiedInputs)
+			{
+				if (txFetchedFromBlocks.TryGetValue(input.PrevOut.Hash, out var tx))
+				{
+					input.NonWitnessUtxo = tx;
+					externallyFetchedTxs.Add(tx);
+					satifiedInput.Add(input);
+				}
+			}
+
+			if (rpc is not null && unSatisfiedInputs.Any())
+			{
+				try
+				{
+					update.PSBT = await rpc.UTXOUpdatePSBT(update.PSBT);
+				}
+				// Best effort
+				catch (RPCException ex) when (ex.RPCCode == RPCErrorCode.RPC_METHOD_NOT_FOUND)
+				{
+				}
+				catch
+				{
+				}
+			}
+
+			// Slim the UTXO if we can. We don't need to check AlwaysIncludeNonWitnessUTXO here. The requirement takes account of it.
+			foreach (var r in inputWithRequirements)
+			{
+				if (r.Requirement is UTXORequirement.WitnessUTXO or UTXORequirement.Unknown && r.Input.NonWitnessUtxo is not null)
+					r.Input.TrySlimUTXO();
+				if (r.Input.NonWitnessUtxo is not null)
+					r.Input.WitnessUtxo = null;
+			}
+
+			await repo.SaveTransactionRaw(externallyFetchedTxs);
+		}
+	}
+}

--- a/NBXplorer/Utils.cs
+++ b/NBXplorer/Utils.cs
@@ -114,7 +114,7 @@ namespace NBXplorer
 				Confirmations = result.BlockHeight is long bh ? height - bh + 1 : 0,
 				BlockId = result.BlockHash,
 				Transaction = result.Transaction,
-				TransactionHash = result.Transaction.GetHash(),
+				TransactionHash = result.TxId,
 				Height = result.BlockHeight,
 				Timestamp = result.Timestamp,
 				ReplacedBy = result.ReplacedBy,


### PR DESCRIPTION
When a PSBT is created or updated, NBXplorer may not always have information about the `NonWitnessUTXO`.
This can happen after restoring a wallet through `Scanutxoset`, as the UTXO set contains only UTXOs, not the full transactions.

However, some non-SegWit wallets require this information to properly verify the fees of a PSBT. In such cases, this refactoring attempts to use GetBlock from the local node, as well as [getblockfrompeer](https://bitcoincore.org/en/doc/26.0.0/rpc/blockchain/getblockfrompeer/) if the block is unavailable (e.g., on a pruned node).
The tx will then be saved in the database for future, faster use.

Note that this only applies to UTXOs tracked by NBXplorer and requires [getblockfrompeer](https://bitcoincore.org/en/doc/26.0.0/rpc/blockchain/getblockfrompeer/) support by RPC. (Bitcoin Core 26.0 and above)