### PR TITLE
Fix documentation AI slop, allow more format for broadcasting

### DIFF
--- a/NBXplorer.Client/NBXplorer.Client.csproj
+++ b/NBXplorer.Client/NBXplorer.Client.csproj
@@ -30,6 +30,9 @@
 		<PackageReference Include="NBitcoin" Version="9.0.0" />
 		<PackageReference Include="NBitcoin.Altcoins" Version="5.0.0" />
 	</ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="NBXplorer.Tests" />
+    </ItemGroup>
   <ItemGroup>
 	<None Include="..\README.md" Pack="true" PackagePath="\" />
 	<None Include="Bitcoin.png" Pack="true" PackagePath="\" />

--- a/NBXplorer/NBXplorer.csproj
+++ b/NBXplorer/NBXplorer.csproj
@@ -46,6 +46,9 @@
     <ProjectReference Include="..\NBXplorer.Client\NBXplorer.Client.csproj" />
   </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="NBXplorer.Tests" />
+    </ItemGroup>
   <ItemGroup>
     <Resource Include="DBScripts\001.Migrations.sql" />
   </ItemGroup>

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "NBXPLORER_POSTGRES": "User ID=postgres;Application Name=test;Include Error Detail=true;Host=localhost;Port=39383",
-        "NBXPLORER_BTCSTARTHEIGHT": "860200",
+        "NBXPLORER_BTCSTARTHEIGHT": "911478",
         "NBXPLORER_BTCRESCAN": "1",
         "NBXPLORER_BTCRPCCOOKIEFILE": "D:\\Bitcoin\\.cookie"
       },

--- a/NBXplorer/wwwroot/api.json
+++ b/NBXplorer/wwwroot/api.json
@@ -1755,16 +1755,9 @@
                 "properties": {
                   "hex": {
                     "type": "string",
-                    "description": "The raw transaction in hexadecimal format."
-                  },
-                  "psbt": {
-                    "type": "string",
-                    "description": "The PSBT in Base64 encoding."
+                    "description": "The raw transaction in hexadecimal format, or finalized PSBT in Base64 or hex.",
+                    "example": "0200000001..."
                   }
-                },
-                "example": {
-                  "hex": "0200000001abcd1234...",
-                  "psbt": "cHNidP8BAHECAAAA..."
                 }
               }
             }
@@ -1778,16 +1771,26 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "transactionId": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the transaction was successfully broadcast.",
+                      "example": false
+                    },
+                    "rpcCode": {
+                      "type": "integer",
+                      "description": "The RPC code returned by the node.",
+                      "example": -25
+                    },
+                    "rpcCodeMessage": {
                       "type": "string",
-                      "description": "The ID of the transaction."
+                      "description": "The error code message returned during transaction submission.",
+                      "example": "General error during transaction submission"
+                    },
+                    "rpcMessage": {
+                      "type": "string",
+                      "description": "The detailed RPC message returned by the node.",
+                      "example": "bad-txns-inputs-missingorspent"
                     }
-                  },
-                  "required": [
-                    "transactionId"
-                  ],
-                  "example": {
-                    "transactionId": "abcd1234..."
                   }
                 }
               }
@@ -3670,77 +3673,6 @@
                 },
                 "example": {
                   "totalPruned": 10
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/cryptos/{cryptoCode}/broadcast": {
-      "post": {
-        "summary": "Broadcast a transaction",
-        "operationId": "Broadcast",
-        "description": "Broadcasts a raw transaction to the network for the specified cryptocurrency.",
-        "tags": [
-          "Transactions"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/CryptoCode"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "hex": {
-                    "type": "string",
-                    "description": "The raw transaction in hexadecimal format."
-                  }
-                },
-                "required": [
-                  "hex"
-                ]
-              },
-              "example": {
-                "hex": "0200000001abcd1234..."
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Transaction broadcast successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "transactionId": {
-                      "type": "string",
-                      "description": "The ID of the broadcasted transaction."
-                    }
-                  },
-                  "required": [
-                    "transactionId"
-                  ],
-                  "example": {
-                    "transactionId": "abcd1234..."
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request. Invalid transaction data.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }


### PR DESCRIPTION
Allow more format to be parsed by the Broadcast route, and remove an AI slop.

```json
{
    "hex": "0103292..."
}
```