### PR TITLE
Add chunk fee and weight to transaction metadata

### DIFF
--- a/NBXplorer.Client/Models/TransactionMetadata.cs
+++ b/NBXplorer.Client/Models/TransactionMetadata.cs
@@ -10,6 +10,18 @@ namespace NBXplorer.Models
 {
 	public class TransactionMetadata
 	{
+		public class ChunkMetadata
+		{
+			[JsonProperty("fees", DefaultValueHandling = DefaultValueHandling.Ignore)]
+			[JsonConverter(typeof(NBXplorer.JsonConverters.MoneyJsonConverter))]
+			public Money Fees { get; set; }
+			[JsonProperty("weight", DefaultValueHandling = DefaultValueHandling.Ignore)]
+			public int Weight { get; set; }
+			[JsonProperty("feeRate", DefaultValueHandling = DefaultValueHandling.Ignore)]
+			[JsonConverter(typeof(NBitcoin.JsonConverters.FeeRateJsonConverter))]
+			public FeeRate FeeRate { get; set; }
+		}
+
 		[JsonProperty("vsize", DefaultValueHandling = DefaultValueHandling.Ignore)]
 		public int? VirtualSize { get; set; }
 		[JsonProperty("fees", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -18,10 +30,10 @@ namespace NBXplorer.Models
 		[JsonProperty("feeRate", DefaultValueHandling = DefaultValueHandling.Ignore)]
 		[JsonConverter(typeof(NBitcoin.JsonConverters.FeeRateJsonConverter))]
 		public FeeRate FeeRate { get; set; }
+		public ChunkMetadata Chunk { get; set; }
 		public static TransactionMetadata Parse(string json) => JsonConvert.DeserializeObject<TransactionMetadata>(json);
 		public string ToString(bool indented) => JsonConvert.SerializeObject(this, indented ? Formatting.Indented : Formatting.None);
 		public override string ToString() => ToString(true);
-
 		[JsonExtensionData]
 		public IDictionary<string, JToken> AdditionalData { get; set; } = new Dictionary<string, JToken>();
 	}

--- a/NBXplorer.Client/NBXplorer.Client.csproj
+++ b/NBXplorer.Client/NBXplorer.Client.csproj
@@ -27,7 +27,7 @@
 		  <NoWarn>$(NoWarn);1591;1573;1572;1584;1570;3021</NoWarn>
         </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="NBitcoin" Version="10.0.1" />
+		<PackageReference Include="NBitcoin" Version="10.0.2" />
 		<PackageReference Include="NBitcoin.Altcoins" Version="6.0.3" />
 	</ItemGroup>
     <ItemGroup>

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -2724,6 +2724,14 @@ namespace NBXplorer.Tests
 				Assert.NotNull(metadata.Fees);
 				Assert.NotNull(metadata.FeeRate);
 				Assert.NotNull(metadata.VirtualSize);
+				Assert.NotNull(metadata.Chunk);
+				Assert.NotNull(metadata.Chunk.Fees);
+				Assert.NotEqual(0, metadata.Chunk.Fees.Satoshi);
+				Assert.NotEqual(0, metadata.Chunk.Weight);
+				Assert.NotNull(metadata.Chunk.FeeRate);
+				// Those are equal because the chunk is composed of a single transaction
+				Assert.Equal(metadata.Chunk.FeeRate, metadata.FeeRate);
+				Assert.Equal((metadata.Chunk.Weight + 3) / 4, metadata.VirtualSize);
 			}
 		}
 

--- a/NBXplorer/RPCClientExtensions.cs
+++ b/NBXplorer/RPCClientExtensions.cs
@@ -152,8 +152,15 @@ namespace NBXplorer
 		=> new()
 		{
 			Fees = entry.BaseFee,
+			Chunk = entry.ChunkFees is null || entry.ChunkWeight is 0 ? null :
+				new TransactionMetadata.ChunkMetadata()
+				{
+					Fees = entry.ChunkFees,
+					Weight = entry.ChunkWeight,
+					FeeRate = GetFeeRate(entry.ChunkFees, ((entry.ChunkWeight + 3) / 4)),
+				},
 			VirtualSize = entry.VirtualSizeBytes,
-			FeeRate = GetFeeRate(entry.BaseFee, entry.VirtualSizeBytes)
+			FeeRate = GetFeeRate(entry.BaseFee, entry.VirtualSizeBytes),
 		};
 
 		// This method fetch some information from getmempoolentry which may be useful for analysis, it's not critical to have it, so we don't want to fail the whole thing if it fails.

--- a/NBXplorer/wwwroot/api.json
+++ b/NBXplorer/wwwroot/api.json
@@ -107,6 +107,31 @@
             "description": "The estimated fee rate in satoshis per vByte. Only available if the transaction has been indexed when it was in the mempool.",
             "example": 20.0,
             "nullable": true
+          },
+          "chunk": {
+            "type": "object",
+            "description": "Fee metadata for the transaction chunk, as reported by Bitcoin Core mempool entry data.",
+            "nullable": true,
+            "properties": {
+              "fees": {
+                "type": "integer",
+                "description": "Total fee of this chunk in satoshi.",
+                "example": 2820,
+                "nullable": true
+              },
+              "weight": {
+                "type": "integer",
+                "description": "Total chunk weight in weight units.",
+                "example": 564,
+                "nullable": true
+              },
+              "feeRate": {
+                "type": "number",
+                "description": "Chunk fee rate in satoshis per vByte.",
+                "example": 20.0,
+                "nullable": true
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Bitcoin core 31.0 includes this information which is very useful to estimate fees for RBF and CPFP more accuratly.