### PR TITLE
Add `curl` to Docker image to support health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN cd NBXplorer && \
 FROM mcr.microsoft.com/dotnet/aspnet:10.0.6-noble
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /datadir
 ENV NBXPLORER_DATADIR=/datadir
 VOLUME /datadir


### PR DESCRIPTION
Adds `curl` as a tool in the Docker image in case operators want to specify HTTP based health checks to ensure HTTP server and/or RPC connectivity is ready before starting dependent containers.