### PR TITLE
Allow mingapsize to equal maxgapsize (fix #180)

### DIFF
--- a/NBXplorer/Configuration/ExplorerConfiguration.cs
+++ b/NBXplorer/Configuration/ExplorerConfiguration.cs
@@ -162,7 +162,7 @@ namespace NBXplorer.Configuration
 			Logs.Configuration.LogInformation("Supported chains: " + String.Join(',', supportedChains.ToArray()));
 			MinGapSize = config.GetOrDefault<int>("mingapsize", 20);
 			MaxGapSize = config.GetOrDefault<int>("maxgapsize", 30);
-			if (MinGapSize >= MaxGapSize)
+			if (MinGapSize > MaxGapSize)
 				throw new ConfigException("mingapsize should be equal or lower than maxgapsize");
 			if(!Directory.Exists(BaseDataDir))
 				Directory.CreateDirectory(BaseDataDir);


### PR DESCRIPTION
The startup configuration check rejects `mingapsize == maxgapsize` with `if (MinGapSize >= MaxGapSize)`, even though the accompanying error message says *"mingapsize should be equal or lower than maxgapsize"*. The two contradict each other, and equal values are a valid configuration.

`MinGapSize`/`MaxGapSize` become the address pool's `MinPoolSize`/`MaxPoolSize`, and `Repository.ToGenerateCount` treats them as an inclusive `[min, max]` band — refilling up to `MaxPoolSize` once the unused-address gap drops below `MinPoolSize`. When the two are equal this simply keeps a fixed-size buffer, which works fine.

This changes the guard to `>` so only the genuinely invalid case (min strictly greater than max) is rejected, matching what the error message already promises.

Fixes #180.